### PR TITLE
Changing the call that generates passwords to one that does attempt to g...

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,3 +1,4 @@
+# Handles Apache cert configuration
 class certs::apache (
     $hostname        = $::certs::node_fqdn,
     $generate        = $::certs::generate,

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -18,26 +18,22 @@ class certs::candlepin (
   Exec { logoutput => 'on_failure' }
 
   if $deploy {
+
+    File[$certs::pki_dir] ~>
     file { $keystore_password_file:
       ensure  => file,
       content => $keystore_password,
-      mode    => '0644',
+      mode    => '0600',
       owner   => 'tomcat',
-      group   => $::certs::user_groups,
+      group   => $::certs::group,
       replace => false;
-    } ~>
-    file { $pki_dir:
-      ensure => directory,
-      owner  => 'root',
-      group  => $::certs::user_groups,
-      mode   => '0750',
     } ~>
     pubkey { $ca_cert:
       cert => $ca,
     } ~>
     file { $ca_cert:
       owner   => 'root',
-      group   => $::certs::user_groups,
+      group   => $::certs::group,
       mode    => '0644';
     } ~>
     privkey { $ca_key:
@@ -46,7 +42,7 @@ class certs::candlepin (
     } ~>
     file { $ca_key:
       owner   => 'root',
-      group   => $::certs::user_groups,
+      group   => $::certs::group,
       mode    => '0640';
     } ~>
     exec { 'generate-ssl-keystore':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,11 @@
+# Certs Configuration
+class certs::config {
+
+  file { $certs::pki_dir:
+    ensure  => directory,
+    owner   => 'root',
+    group   => $certs::group,
+    mode    => '0750',
+  }
+
+}

--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -1,3 +1,4 @@
+# Handles Foreman certs configuration
 class certs::foreman (
     $hostname    = $::certs::node_fqdn,
     $generate    = $::certs::generate,
@@ -35,8 +36,9 @@ class certs::foreman (
     } ->
 
     file { $client_key:
-      owner => "foreman",
-      mode  => "0400"
+      ensure  => file,
+      owner   => 'foreman',
+      mode    => '0400',
     }
 
     pubkey { $client_ca:

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -1,3 +1,4 @@
+# Handles Foreman Proxy cert configuration
 class certs::foreman_proxy (
     $hostname   = $::certs::node_fqdn,
     $generate   = $::certs::generate,
@@ -35,8 +36,9 @@ class certs::foreman_proxy (
     } ->
 
     file { $proxy_key:
-      owner => "foreman-proxy",
-      mode  => "0400"
+      ensure  => file,
+      owner   => 'foreman-proxy',
+      mode    => '0400'
     }
 
     pubkey { $proxy_ca:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,14 @@
 # $ca_expiration::        Ca expiration attribute for managed certificates
 #                         type: string
 #
+# $custom_repo::          If set to true, no repo will be added allowing custom installation
+#                         type: boolean
+#
+# $user::               The Katello system user name;
+#                       default 'katello'
+#
+# $group::              The Katello system user group;
+#                       default 'katello'
 class certs (
 
   $log_dir        = $certs::params::log_dir,
@@ -66,16 +74,25 @@ class certs (
   $org_unit       = $certs::params::org_unit,
 
   $expiration     = $certs::params::expiration,
-  $ca_expiration  = $certs::params::ca_expiration
+  $ca_expiration  = $certs::params::ca_expiration,
+
+  $pki_dir = $::certs::params::candlepin_pki_dir,
+
+  $candlepin_keystore_password_file = $certs::params::candlepin_keystore_password_file,
+  $candlepin_keystore_password = $certs::params::candlepin_keystore_password,
+
+  $custom_repo = $certs::params::custom_repo,
+
+  $user   = $certs::params::user,
+  $group  = $certs::params::group
+
   ) inherits certs::params {
 
-  $user_groups            = $certs::params::user_groups
-  $nss_db_dir             = $certs::params::nss_db_dir
+  $nss_db_dir   = $certs::params::nss_db_dir
+  $default_ca   = Ca['candlepin-ca']
 
-  class { 'certs::install': }
-
-  $default_ca = Ca['candlepin-ca']
-
+  class { 'certs::install': } ->
+  class { 'certs::config': } ->
   ca { 'candlepin-ca':
     ensure      => present,
     common_name => $certs::ca_common_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,15 @@
 # Certs Installation
 class certs::install {
-  package{['katello-certs-tools']:
-    ensure => installed,
+  include katello::install
+
+  $repo = $certs::custom_repo ? {
+    false   => [Katello::Install::Repos['katello']],
+    default => []
   }
+
+  package{['katello-certs-tools']:
+    ensure  => installed,
+    require => $repo
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,8 @@ class certs::params {
 
   $node_fqdn = $::fqdn
 
+  $custom_repo = false
+
   $ca_common_name = $::fqdn  # we need fqdn as CA common name as candlepin uses it as a ssl cert
 
   $generate      = true
@@ -31,7 +33,8 @@ class certs::params {
   $nss_db_dir             = '/etc/pki/katello/nssdb'
   $ssl_pk12_password_file = '/etc/katello/pk12_password-file'
 
-  $user_groups = 'foreman'
+  $user = 'root'
+  $group = 'root'
 
   $foreman_client_cert = '/etc/foreman/client_cert.pem'
   $foreman_client_key  = '/etc/foreman/client_key.pem'
@@ -55,7 +58,7 @@ class certs::params {
   $candlepin_pki_dir                = '/etc/pki/katello'
   $candlepin_keystore               = '/etc/pki/katello/keystore'
   $candlepin_keystore_password_file = '/etc/katello/keystore_password-file'
-  $candlepin_keystore_password      = find_or_create_password($candlepin_keystore_password_file)
+  $candlepin_keystore_password      = generate_password()
   $candlepin_certs_dir              = '/etc/candlepin/certs'
 
 }

--- a/manifests/pulp_parent.pp
+++ b/manifests/pulp_parent.pp
@@ -1,13 +1,17 @@
 # Pulp Master Certs configuration
 class certs::pulp_parent (
-    $hostname = $::certs::node_fqdn,
-    $generate = $::certs::generate,
+    $hostname   = $::certs::node_fqdn,
+    $generate   = $::certs::generate,
     $regenerate = $::certs::regenerate,
-    $deploy   = $::certs::deploy,
-    $ca       = $::certs::default_ca,
-    $nodes_cert = '/etc/pki/pulp/nodes/node.crt',
-    $messaging_ca_cert = $pulp::params::messaging_ca_cert,
-    $messaging_client_cert = $pulp::params::messaging_client_cert
+    $deploy     = $::certs::deploy,
+    $ca         = $::certs::default_ca,
+
+    $nodes_cert_dir = '/etc/pki/pulp/nodes',
+    $nodes_cert     = 'node.crt',
+
+    $messaging_ca_cert      = $pulp::params::messaging_ca_cert,
+    $messaging_client_cert  = $pulp::params::messaging_client_cert
+
   ) inherits pulp::params {
 
   # cert for nodes authenitcation
@@ -44,7 +48,14 @@ class certs::pulp_parent (
   }
 
   if $deploy {
-    key_bundle { $::certs::pulp_parent::nodes_cert:
+
+    file { $nodes_cert_dir:
+      ensure  => directory,
+      owner   => $certs::user,
+      group   => $certs::group,
+      mode    => '0755',
+    } ->
+    key_bundle { "${nodes_cert_dir}/${::certs::pulp_parent::nodes_cert}":
       cert => Cert["${::certs::pulp_parent::hostname}-parent-cert"],
     }
 

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -1,3 +1,4 @@
+# Class for handling Puppet cert configuration
 class certs::puppet (
     $hostname    = $::certs::node_fqdn,
     $generate    = $::certs::generate,
@@ -35,8 +36,9 @@ class certs::puppet (
     } ->
 
     file { $client_key:
-      owner => "puppet",
-      mode  => "0400",
+      ensure  => file,
+      owner   => 'puppet',
+      mode    => '0400',
     }
 
     pubkey { $client_ca:

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -1,9 +1,12 @@
+# Handles Qpid cert configuration
 class certs::qpid (
+
   $hostname = $::certs::node_fqdn,
   $generate = $::certs::generate,
   $regenerate = $::certs::regenerate,
   $deploy   = $::certs::deploy,
   $ca       = $::certs::default_ca
+
   ){
 
   Exec { logoutput => 'on_failure' }
@@ -35,6 +38,7 @@ class certs::qpid (
       $pfx_path               = "/etc/pki/katello/${qpid_cert_name}.pfx"
       $nssdb_files            = ["${::certs::nss_db_dir}/cert8.db", "${::certs::nss_db_dir}/key3.db", "${::certs::nss_db_dir}/secmod.db"]
 
+      File[$certs::pki_dir] ~>
       pubkey { $client_cert:
         cert => Cert["${::certs::qpid::hostname}-qpid-broker"]
       } ~>
@@ -43,7 +47,7 @@ class certs::qpid (
       } ~>
       file { $client_key:
         owner   => 'root',
-        group   => $::certs::user_groups,
+        group   => $::certs::group,
         mode    => '0400',
       } ~>
       exec { 'generate-nss-password':
@@ -53,7 +57,7 @@ class certs::qpid (
       } ->
       file { $nss_db_password_file:
         owner   => 'root',
-        group   => $::certs::user_groups,
+        group   => $::certs::group,
         mode    => '0640',
       } ~>
       exec { 'generate-pk12-password':
@@ -70,7 +74,7 @@ class certs::qpid (
       file { $::certs::nss_db_dir:
         ensure => directory,
         owner  => 'root',
-        group  => $certs::user_groups,
+        group  => $certs::group,
         mode   => '0744',
       } ~>
       exec { 'create-nss-db':
@@ -80,7 +84,7 @@ class certs::qpid (
       } ~>
       file { $nssdb_files:
         owner   => 'root',
-        group   => $::certs::user_groups,
+        group   => $::certs::group,
         mode    => '0640',
       } ~>
       exec { 'add-broker-cert-to-nss-db':


### PR DESCRIPTION
...enerate

the password file at the same time. This throws errors when the RPM that
generates the password file storage locations hasn't been first installed.
