### PR TITLE
Addresses changes made to katello-certs-tools regarding location of

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .vagrant
 *.swp
 *.swo
+*.swm
+*.swn
 
 .bundle
 vendor/

--- a/lib/puppet/provider/ca/katello_ssl_tool.rb
+++ b/lib/puppet/provider/ca/katello_ssl_tool.rb
@@ -3,30 +3,13 @@ require File.expand_path('../../katello_ssl_tool', __FILE__)
 
 Puppet::Type.type(:ca).provide(:katello_ssl_tool, :parent => Puppet::Provider::KatelloSslTool::Cert) do
 
-  def self.privkey(name)
-    # TODO: just temporarily until we have this changes in katello installer as well
-    if name == 'candlepin-ca'
-      build_path('candlepin-cert.key')
-    else
-      target_path("private/#{name}.key")
-    end
-  end
-
   protected
 
-  def generate_passphrase
-    @passphrase ||= generate_random_password
-    passphrase_dir = File.dirname(passphrase_file)
-    FileUtils.mkdir_p(passphrase_dir) unless File.exists?(passphrase_dir)
-    File.open(passphrase_file, 'w') { |f| f << @passphrase }
-    return @passphrase
-  end
-
   def generate!
-    passphrase = generate_passphrase
     katello_ssl_tool('--gen-ca',
-                     '-p', passphrase,
+                     '-p', "file:#{resource[:password_file]}",
                      '--force',
+                     '--ca-cert-dir', target_path('certs'),
                      '--set-common-name', resource[:common_name],
                      '--ca-cert', File.basename(pubkey),
                      '--ca-key', File.basename(privkey),
@@ -35,33 +18,15 @@ Puppet::Type.type(:ca).provide(:katello_ssl_tool, :parent => Puppet::Provider::K
   end
 
   def files_to_generate
-    [rpmfile, privkey, passphrase_file]
+    [rpmfile, privkey]
   end
 
   def files_to_deploy
     [pubkey]
   end
 
-  # TODO: just temporarily until we have this changes in katello installer as well
-  def rpmfile_base_name
-    if resource[:name] == 'candlepin-ca'
-      'katello-candlepin-cert-key-pair'
-    else
-      super
-    end
-  end
-
-  def generate_random_password
-    size = 20
-    # These are quite often confusing ...
-    ambiguous_characters = %w(0 1 O I l)
-
-    # Get allowed characters set ...
-    set = ('a' .. 'z').to_a + ('A' .. 'Z').to_a + ('0' .. '9').to_a
-    set = set - ambiguous_characters
-
-    # Shuffle characters in the set at random and return desired number of them ...
-    return size.times.collect {|i| set[rand(set.size)] }.join
+  def self.privkey(name)
+    build_path("#{name}.key")
   end
 
 end

--- a/lib/puppet/provider/cert/katello_ssl_tool.rb
+++ b/lib/puppet/provider/cert/katello_ssl_tool.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:cert).provide(:katello_ssl_tool, :parent => Puppet::Provider:
     resource[:common_name] ||= resource[:hostname]
     purpose = resource[:purpose]
     katello_ssl_tool("--gen-#{purpose}",
-                     '-p', ca_details[:passphrase],
+                     '-p', "file:#{resource[:password_file]}",
                      '--set-hostname', resource[:hostname],
                      '--set-common-name', resource[:common_name],
                      '--ca-cert', ca_details[:pubkey],

--- a/lib/puppet/provider/key_bundle/katello_ssl_tool.rb
+++ b/lib/puppet/provider/key_bundle/katello_ssl_tool.rb
@@ -9,8 +9,12 @@ Puppet::Type.type(:key_bundle).provide(:katello_ssl_tool, :parent => Puppet::Pro
   end
 
   def pubkey
-    # strips the textual info from the certificate file
-    openssl('x509', '-in', pubkey_source_path)
+    if resource[:strip]
+      # strips the textual info from the certificate file
+      openssl('x509', '-in', pubkey_source_path)
+    else
+      File.read(pubkey_source_path)
+    end
   end
 
   def privkey

--- a/lib/puppet/provider/privkey/katello_ssl_tool.rb
+++ b/lib/puppet/provider/privkey/katello_ssl_tool.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:privkey).provide(:katello_ssl_tool, :parent => Puppet::Provid
         openssl('rsa',
                 '-in', source_path,
                 '-out', tmp_file,
-                '-passin', "file:#{cert_details[:passphrase_file]}")
+                '-passin', "file:#{resource[:password_file]}")
         File.read(tmp_file)
       ensure
         File.delete(tmp_file) if File.exists?(tmp_file)
@@ -22,7 +22,11 @@ Puppet::Type.type(:privkey).provide(:katello_ssl_tool, :parent => Puppet::Provid
   end
 
   def source_path
-    cert_details[:privkey]
+    if @resource[:key_pair].type == 'Cert'
+      cert_details[:privkey]
+    elsif @resource[:key_pair].type == 'Ca'
+      Puppet::Type::Ca::ProviderKatello_ssl_tool.privkey(@resource[:key_pair].to_hash[:name])
+    end
   end
 
   def mode

--- a/lib/puppet/provider/pubkey/katello_ssl_tool.rb
+++ b/lib/puppet/provider/pubkey/katello_ssl_tool.rb
@@ -5,8 +5,12 @@ Puppet::Type.type(:pubkey).provide(:katello_ssl_tool, :parent => Puppet::Provide
   protected
 
   def expected_content
-    # strips the textual info from the certificate file
-    openssl('x509', '-in', source_path)
+    if resource[:strip]
+      # strips the textual info from the certificate file
+      openssl('x509', '-in', source_path)
+    else
+      File.read(source_path)
+    end
   end
 
   def source_path

--- a/lib/puppet/type/certs_common.rb
+++ b/lib/puppet/type/certs_common.rb
@@ -29,6 +29,8 @@ module Certs
     newparam(:regenerate)
 
     newparam(:deploy)
+
+    newparam(:password_file)
   end
 
   FILE_COMMON_PARAMS = Proc.new do
@@ -36,35 +38,27 @@ module Certs
 
     newparam(:path, :namevar => true)
 
+    newparam(:password_file)
+
     # make ensure present default
     define_method(:managed?) { true }
 
-    newparam(:cert) do
-      # TODO: should be required
+    newparam(:key_pair) do
       validate do |value|
-        unless value.is_a?(Puppet::Resource) && [:ca, :cert].include?(value.resource_type.name)
-          raise ArgumentError, "Expected Cert or Ca resource"
+        unless value.is_a?(Puppet::Resource) && (value.resource_type.name == :ca || value.resource_type.name == :cert)
+          raise ArgumentError, "Expected Ca or Cert resource"
         end
+      end
+    end
+
+    autorequire(:key_pair) do
+      if @parameters.has_key?(:key_pair)
+        @parameters[:key_pair].value.to_hash[:name]
       end
     end
 
     autorequire(:file) do
       @parameters[:path]
-    end
-
-    autorequire(:cert) do
-      # TODO: find better way how to determine the type
-      if @parameters.has_key?(:cert) &&
-            @parameters[:cert].value.resource_type.name == :cert
-        @parameters[:cert].value.to_hash[:name]
-      end
-    end
-
-    autorequire(:ca) do
-      if @parameters.has_key?(:cert) &&
-            @parameters[:cert].value.resource_type.name == :ca
-        @parameters[:cert].value.to_hash[:name]
-      end
     end
 
   end

--- a/lib/puppet/type/key_bundle.rb
+++ b/lib/puppet/type/key_bundle.rb
@@ -8,4 +8,7 @@ Puppet::Type.newtype(:key_bundle) do
   newparam(:pubkey)
 
   newparam(:privkey)
+
+  # Whether to strip the certificate information from the pubkey
+  newparam(:strip)
 end

--- a/lib/puppet/type/privkey.rb
+++ b/lib/puppet/type/privkey.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../certs_common', __FILE__)
 
 Puppet::Type.newtype(:privkey) do
-  desc 'Stores the private key file on a location'
+  desc 'Stores the private key file in a location'
 
   instance_eval(&Certs::FILE_COMMON_PARAMS)
 

--- a/lib/puppet/type/pubkey.rb
+++ b/lib/puppet/type/pubkey.rb
@@ -1,7 +1,10 @@
 require File.expand_path('../certs_common', __FILE__)
 
 Puppet::Type.newtype(:pubkey) do
-  desc 'Stores the public key file on a location'
+  desc 'Stores the public key file in a location'
 
   instance_eval(&Certs::FILE_COMMON_PARAMS)
+
+  # will generate a key with the certificate information stripped
+  newparam(:strip)
 end

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -1,66 +1,46 @@
 # Constains certs specific configurations for candlepin
 class certs::candlepin (
-    $hostname               = $::certs::node_fqdn,
-    $generate               = $::certs::generate,
-    $regenerate             = $::certs::regenerate,
-    $deploy                 = $::certs::deploy,
-    $ca                     = $::certs::default_ca,
-    $storage                = $::certs::params::candlepin_certs_storage,
-    $ca_cert                = $::certs::params::candlepin_ca_cert,
-    $ca_key                 = $::certs::params::candlepin_ca_key,
-    $pki_dir                = $::certs::params::candlepin_pki_dir,
-    $keystore               = $::certs::params::candlepin_keystore,
-    $keystore_password_file = $::certs::candlepin_keystore_password_file,
-    $keystore_password      = $::certs::candlepin_keystore_password,
-    $candlepin_certs_dir    = $::certs::params::candlepin_certs_dir
+
+  $hostname               = $::certs::node_fqdn,
+  $generate               = $::certs::generate,
+  $regenerate             = $::certs::regenerate,
+  $deploy                 = $::certs::deploy,
+  $ca                     = $::certs::default_ca,
+  $storage                = $::certs::params::candlepin_certs_storage,
+  $ca_cert                = $::certs::ca_cert_stripped,
+  $ca_key                 = $::certs::ca_key,
+  $pki_dir                = $::certs::params::pki_dir,
+  $keystore               = $::certs::params::candlepin_keystore,
+  $keystore_password_file = $::certs::params::keystore_password_file,
+  $candlepin_certs_dir    = $::certs::params::candlepin_certs_dir
+
   ) inherits certs::params {
 
   Exec { logoutput => 'on_failure' }
 
+  $keystore_password = cache_data($keystore_password_file, random_password(32))
+  $password_file = "${certs::pki_dir}/keystore_password-file"
+
   if $deploy {
 
-    File[$certs::pki_dir] ~>
-    file { $keystore_password_file:
+    file { $password_file:
       ensure  => file,
       content => $keystore_password,
-      mode    => '0600',
-      owner   => 'tomcat',
-      group   => $::certs::group,
-      replace => false;
-    } ~>
-    pubkey { $ca_cert:
-      cert => $ca,
-    } ~>
-    file { $ca_cert:
-      ensure  => file,
-      owner   => 'root',
-      group   => $::certs::group,
-      mode    => '0644';
-    } ~>
-    privkey { $ca_key:
-      cert      => $ca,
-      unprotect => true;
-    } ~>
-    file { $ca_key:
-      ensure  => file,
-      owner   => 'root',
-      group   => $::certs::group,
-      mode    => '0640',
+      owner   => $certs::user,
+      group   => $certs::group,
+      mode    => '0440',
     } ~>
     exec { 'generate-ssl-keystore':
-      command   => "openssl pkcs12 -export -in ${ca_cert} -inkey ${ca_key} -out ${keystore} -name tomcat -CAfile ${ca_cert} -caname root -password \"file:${keystore_password_file}\"",
+      command   => "openssl pkcs12 -export -in ${ca_cert} -inkey ${ca_key} -out ${keystore} -name tomcat -CAfile ${ca_cert} -caname root -password \"file:${password_file}\" -passin \"file:${certs::ca_key_password_file}\" ",
       path      => '/bin:/usr/bin',
-      creates   => $keystore;
+      creates   => $keystore,
     } ~>
     file { "/usr/share/${candlepin::tomcat}/conf/keystore":
       ensure  => link,
-      target  => $keystore;
-    } ~>
-    exec { 'add-candlepin-cert-to-nss-db':
-      command     => "certutil -A -d '${::certs::nss_db_dir}' -n 'ca' -t 'TCu,Cu,Tuw' -a -i '${ca_cert}'",
-      path        => '/usr/bin',
-      subscribe   => Exec['create-nss-db'],
-      refreshonly => true,
+      target  => $keystore,
+      owner   => 'tomcat',
+      group   => $::certs::group,
+      notify  => Service[$candlepin::tomcat]
     }
 
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,20 @@ class certs::config {
     ensure  => directory,
     owner   => 'root',
     group   => $certs::group,
+    mode    => '0755',
+  }
+
+  file { "${certs::pki_dir}/certs":
+    ensure  => directory,
+    owner   => 'root',
+    group   => $certs::group,
+    mode    => '0755',
+  }
+
+  file { "${certs::pki_dir}/private":
+    ensure  => directory,
+    owner   => 'root',
+    group   => $certs::group,
     mode    => '0750',
   }
 

--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -1,54 +1,59 @@
 # Handles Foreman certs configuration
 class certs::foreman (
-    $hostname    = $::certs::node_fqdn,
-    $generate    = $::certs::generate,
-    $regenerate  = $::certs::regenerate,
-    $deploy      = $::certs::deploy,
-    $ca          = $::certs::default_ca,
-    $client_cert = $::certs::params::foreman_client_cert,
-    $client_key  = $::certs::params::foreman_client_key,
-    $client_ca   = $::certs::params::foreman_client_ca
+
+  $hostname       = $::certs::node_fqdn,
+  $generate       = $::certs::generate,
+  $regenerate     = $::certs::regenerate,
+  $deploy         = $::certs::deploy,
+  $ca             = $::certs::default_ca,
+  $client_cert    = $::certs::params::foreman_client_cert,
+  $client_key     = $::certs::params::foreman_client_key,
+  $client_ca_cert = $::certs::params::foreman_client_ca_cert
+
   ) inherits certs::params {
 
+  $client_cert_name = "${::certs::foreman::hostname}-foreman-client"
+
   # cert for authentication of puppetmaster against foreman
-  cert { "${::certs::foreman::hostname}-foreman-client":
-    hostname    => $::certs::foreman::hostname,
-    purpose     => client,
-    country     => $::certs::country,
-    state       => $::certs::state,
-    city        => $::certs::sity,
-    org         => 'FOREMAN',
-    org_unit    => 'PUPPET',
-    expiration  => $::certs::expiration,
-    ca          => $ca,
-    generate    => $generate,
-    regenerate  => $regenerate,
-    deploy      => $deploy,
+  cert { $client_cert_name:
+    hostname      => $::certs::foreman::hostname,
+    purpose       => client,
+    country       => $::certs::country,
+    state         => $::certs::state,
+    city          => $::certs::sity,
+    org           => 'FOREMAN',
+    org_unit      => 'PUPPET',
+    expiration    => $::certs::expiration,
+    ca            => $ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    deploy        => $deploy,
+    password_file => $certs::ca_key_password_file,
   }
 
   if $deploy {
+
+    Cert[$client_cert_name] ~>
     pubkey { $client_cert:
-      cert => Cert["${::certs::foreman::hostname}-foreman-client"],
-    }
-
+      key_pair => Cert[$client_cert_name],
+    } ~>
     privkey { $client_key:
-      cert => Cert["${::certs::foreman::hostname}-foreman-client"],
+      key_pair => Cert[$client_cert_name],
     } ->
-
+    pubkey { $client_ca_cert:
+      key_pair => $ca
+    } ~>
     file { $client_key:
       ensure  => file,
       owner   => 'foreman',
       mode    => '0400',
     }
 
-    pubkey { $client_ca:
-      cert => $ca,
-    }
-
     $foreman_config_cmd = "${::foreman::app_root}/script/foreman-config\
-      -k ssl_ca_file -v '${client_ca}'\
+      -k ssl_ca_file -v '${client_ca_cert}'\
       -k ssl_certificate -v '${client_cert}'\
       -k ssl_priv_key -v '${client_key}'"
+
     exec { 'foreman_certs_config':
       environment => ["HOME=${::foreman::app_root}"],
       cwd         => $::foreman::app_root,

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -1,48 +1,55 @@
 # Handles Foreman Proxy cert configuration
 class certs::foreman_proxy (
-    $hostname   = $::certs::node_fqdn,
-    $generate   = $::certs::generate,
-    $regenerate = $::certs::regenerate,
-    $deploy     = $::certs::deploy,
-    $ca         = $::certs::default_ca,
-    $proxy_cert = $::certs::params::foreman_proxy_cert,
-    $proxy_key  = $::certs::params::foreman_proxy_key,
-    $proxy_ca   = $::certs::params::foreman_proxy_ca
+
+  $hostname   = $::certs::node_fqdn,
+  $generate   = $::certs::generate,
+  $regenerate = $::certs::regenerate,
+  $deploy     = $::certs::deploy,
+  $ca         = $::certs::default_ca,
+  $proxy_cert = $::certs::params::foreman_proxy_cert,
+  $proxy_key  = $::certs::params::foreman_proxy_key,
+  $proxy_ca_cert = $::certs::params::foreman_proxy_ca_cert
+
   ) inherits certs::params {
 
+  $proxy_cert_name = "${::certs::foreman_proxy::hostname}-foreman-proxy"
+
   # cert for ssl of foreman-proxy
-  cert { "${::certs::foreman_proxy::hostname}-foreman-proxy":
-    hostname    => $::certs::foreman_proxy::hostname,
-    purpose     => server,
-    country     => $::certs::country,
-    state       => $::certs::state,
-    city        => $::certs::sity,
-    org         => 'FOREMAN',
-    org_unit    => 'SMART_PROXY',
-    expiration  => $::certs::expiration,
-    ca          => $ca,
-    generate    => $generate,
-    regenerate  => $regenerate,
-    deploy      => $deploy,
+  cert { $proxy_cert_name:
+    hostname      => $::certs::foreman_proxy::hostname,
+    purpose       => server,
+    country       => $::certs::country,
+    state         => $::certs::state,
+    city          => $::certs::sity,
+    org           => 'FOREMAN',
+    org_unit      => 'SMART_PROXY',
+    expiration    => $::certs::expiration,
+    ca            => $ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    deploy        => $deploy,
+    password_file => $certs::ca_key_password_file,
   }
 
   if $deploy {
+
+    Cert[$proxy_cert_name] ~>
     pubkey { $proxy_cert:
-      cert => Cert["${::certs::foreman_proxy::hostname}-foreman-proxy"],
-    }
-
+      key_pair => Cert[$proxy_cert_name],
+    } ~>
     privkey { $proxy_key:
-      cert => Cert["${::certs::foreman_proxy::hostname}-foreman-proxy"],
+      key_pair => Cert[$proxy_cert_name],
     } ->
-
+    pubkey { $proxy_ca_cert:
+      key_pair => $ca
+    } ~>
     file { $proxy_key:
       ensure  => file,
       owner   => 'foreman-proxy',
+      group   => $certs::group,
       mode    => '0400'
-    }
+    } ~>
+    Service['foreman-proxy']
 
-    pubkey { $proxy_ca:
-      cert => $ca,
-    }
   }
 }

--- a/manifests/katello.pp
+++ b/manifests/katello.pp
@@ -1,10 +1,8 @@
 # Katello specific certs settings
 class certs::katello {
 
-  $ssl_build_path                 = '/root/ssl-build'
   $katello_www_pub_dir            = '/var/www/html/pub'
-  $candlepin_cert_name            = 'candlepin-ca'
-  $candlepin_consumer_name        = "${candlepin_cert_name}-consumer-${::fqdn}"
+  $candlepin_consumer_name        = "${$certs::default_ca_name}-consumer-${::fqdn}"
   $candlepin_consumer_summary     = "Subscription-manager consumer certificate for Katello instance ${::fqdn}"
   $candlepin_consumer_description = 'Consumer certificate and post installation script that configures rhsm.'
 
@@ -14,13 +12,7 @@ class certs::katello {
     group  => 'apache',
     mode   => '0755';
   } ->
-  file { $ssl_build_path:
-    ensure => directory,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0700';
-  } ->
-  file { "${ssl_build_path}/rhsm-katello-reconfigure":
+  file { "${certs::ssl_build_dir}/rhsm-katello-reconfigure":
     content => template('certs/rhsm-katello-reconfigure.erb'),
     owner   => 'root',
     group   => 'root',
@@ -28,13 +20,14 @@ class certs::katello {
   } ~>
   exec { 'generate-candlepin-consumer-certificate':
     cwd       => $katello_www_pub_dir,
-    command   => "gen-rpm.sh --name '${candlepin_consumer_name}' --version 1.0 --release 1 --packager None --vendor None --group 'Applications/System' --summary '${candlepin_consumer_summary}' --description '${candlepin_consumer_description}' --requires subscription-manager --post ${ssl_build_path}/rhsm-katello-reconfigure /etc/rhsm/ca/candlepin-local.pem:644=${ssl_build_path}/${candlepin_cert_name}.crt && /sbin/restorecon ./*rpm",
-    path      => '/usr/share/katello/certs:/usr/bin:/bin',
+    command   => "katello-certs-gen-rpm --name '${candlepin_consumer_name}' --version 1.0 --release 1 --packager None --vendor None --group 'Applications/System' --summary '${candlepin_consumer_summary}' --description '${candlepin_consumer_description}' --requires subscription-manager --post ${certs::ssl_build_dir}/rhsm-katello-reconfigure /etc/rhsm/ca/candlepin-local.pem:644=${certs::ssl_build_dir}/${$certs::default_ca_name}.crt && /sbin/restorecon ./*rpm",
+    path      => '/usr/bin:/bin',
     creates   => "${katello_www_pub_dir}/${candlepin_consumer_name}-1.0-1.noarch.rpm",
     logoutput => 'on_failure';
   } ~>
-  file { "${katello_www_pub_dir}/${candlepin_cert_name}-consumer-latest.noarch.rpm":
+  file { "${katello_www_pub_dir}/${$certs::default_ca_name}-consumer-latest.noarch.rpm":
     ensure  => 'link',
     target  => "${katello_www_pub_dir}/${candlepin_consumer_name}-1.0-1.noarch.rpm",
   }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,8 @@ class certs::params {
   }
 
   $log_dir = '/var/log/certs'
+  $pki_dir = '/etc/pki/katello'
+  $ssl_build_dir = '/root/ssl-build'
 
   $node_fqdn = $::fqdn
 
@@ -23,6 +25,7 @@ class certs::params {
   $regenerate_ca = false
   $deploy        = true
 
+  $default_ca_name = 'katello-ca'
   $country       = 'US'
   $state         = 'North Carolina'
   $city          = 'Raleigh'
@@ -31,32 +34,29 @@ class certs::params {
   $expiration    = '365'
   $ca_expiration = '36500'
 
-  $password_file_dir  = '/etc/katello'
-  $nss_db_dir = '/etc/pki/katello/nssdb'
+  $keystore_password_file = 'keystore_password-file'
+  $nss_db_dir = "${pki_dir}/nssdb"
 
   $user = 'root'
   $group = 'root'
 
-  $foreman_client_cert = '/etc/foreman/client_cert.pem'
-  $foreman_client_key  = '/etc/foreman/client_key.pem'
-  $foreman_client_ca   = '/etc/foreman/client_ca.pem'
+  $foreman_client_cert    = '/etc/foreman/client_cert.pem'
+  $foreman_client_key     = '/etc/foreman/client_key.pem'
+  $foreman_client_ca_cert = '/etc/foreman/client_ca.pem'
 
-  $foreman_proxy_cert = '/etc/foreman-proxy/ssl_cert.pem'
-  $foreman_proxy_key  = '/etc/foreman-proxy/ssl_key.pem'
-  $foreman_proxy_ca   = '/etc/foreman-proxy/ssl_ca.pem'
+  $foreman_proxy_cert    = '/etc/foreman-proxy/ssl_cert.pem'
+  $foreman_proxy_key     = '/etc/foreman-proxy/ssl_key.pem'
+  $foreman_proxy_ca_cert = '/etc/foreman-proxy/ssl_ca.pem'
 
   $puppet_client_cert = '/etc/puppet/client_cert.pem'
   $puppet_client_key  = '/etc/puppet/client_key.pem'
-  $puppet_client_ca   = '/etc/puppet/client_ca.pem'
+  $puppet_client_ca_cert = '/etc/puppet/client_ca.pem'
 
-  $apache_ssl_cert = '/etc/pki/tls/certs/katello-node.crt'
-  $apache_ssl_key  = '/etc/pki/tls/private/katello-node.key'
-  $apache_ca_cert  = '/etc/pki/tls/certs/katello-ca.crt'
+  $apache_cert_name = 'katello-apache'
 
   $candlepin_certs_storage          = '/etc/candlepin/certs'
   $candlepin_ca_cert                = '/etc/candlepin/certs/candlepin-ca.crt'
   $candlepin_ca_key                 = '/etc/candlepin/certs/candlepin-ca.key'
-  $candlepin_pki_dir                = '/etc/pki/katello'
   $candlepin_keystore               = '/etc/pki/katello/keystore'
   $candlepin_certs_dir              = '/etc/candlepin/certs'
 
@@ -68,6 +68,5 @@ class certs::params {
   $katello_repo_provider  = 'node-installer'
   $katello_product        = 'node-certs'
   $katello_activation_key = undef
-
 
 }

--- a/manifests/pulp_parent.pp
+++ b/manifests/pulp_parent.pp
@@ -1,54 +1,58 @@
 # Pulp Master Certs configuration
 class certs::pulp_parent (
-    $hostname   = $::certs::node_fqdn,
-    $generate   = $::certs::generate,
-    $regenerate = $::certs::regenerate,
-    $deploy     = $::certs::deploy,
-    $ca         = $::certs::default_ca,
 
-    $nodes_cert_dir = '/etc/pki/pulp/nodes',
-    $nodes_cert     = 'node.crt',
+  $hostname   = $::certs::node_fqdn,
+  $generate   = $::certs::generate,
+  $regenerate = $::certs::regenerate,
+  $deploy     = $::certs::deploy,
+  $ca         = $::certs::default_ca,
 
-    $messaging_ca_cert      = $pulp::params::messaging_ca_cert,
-    $messaging_client_cert  = $pulp::params::messaging_client_cert
+  $nodes_cert_dir = '/etc/pki/pulp/nodes',
+  $nodes_cert     = 'node.crt',
+
+  $messaging_ca_cert     = $certs::ca_cert,
+  $messaging_client_cert = '/etc/pki/pulp/qpid_client_striped.crt',
 
   ) inherits pulp::params {
 
   # cert for nodes authenitcation
   cert { "${::certs::pulp_parent::hostname}-parent-cert":
-    hostname    => $certs::pulp_parent::hostname,
-    common_name => 'pulp-child-node-cert',
-    purpose     => client,
-    country     => $::certs::country,
-    state       => $::certs::state,
-    city        => $::certs::sity,
-    org         => 'PULP',
-    org_unit    => 'NODES',
-    expiration  => $::certs::expiration,
-    ca          => $ca,
-    generate    => $generate,
-    regenerate  => $regenerate,
-    deploy      => $deploy,
+    hostname      => $certs::pulp_parent::hostname,
+    common_name   => 'pulp-child-node-cert',
+    purpose       => client,
+    country       => $::certs::country,
+    state         => $::certs::state,
+    city          => $::certs::sity,
+    org           => 'PULP',
+    org_unit      => 'NODES',
+    expiration    => $::certs::expiration,
+    ca            => $ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    deploy        => $deploy,
+    password_file => $certs::ca_key_password_file,
   }
 
   cert { "${::certs::pulp_parent::hostname}-qpid-client-cert":
-    hostname    => $::certs::pulp_parent::hostname,
-    common_name => 'pulp-qpid-client-cert',
-    purpose     => client,
-    country     => $::certs::country,
-    state       => $::certs::state,
-    city        => $::certs::sity,
-    org         => 'PULP',
-    org_unit    => $::certs::org_unit,
-    expiration  => $::certs::expiration,
-    ca          => $ca,
-    generate    => $generate,
-    regenerate  => $regenerate,
-    deploy      => $deploy,
+    hostname      => $::certs::pulp_parent::hostname,
+    common_name   => 'pulp-qpid-client-cert',
+    purpose       => client,
+    country       => $::certs::country,
+    state         => $::certs::state,
+    city          => $::certs::sity,
+    org           => 'PULP',
+    org_unit      => $::certs::org_unit,
+    expiration    => $::certs::expiration,
+    ca            => $ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    deploy        => $deploy,
+    password_file => $certs::ca_key_password_file,
   }
 
   if $deploy {
 
+    Cert["${::certs::pulp_parent::hostname}-parent-cert"] ~>
     file { $nodes_cert_dir:
       ensure  => directory,
       owner   => $certs::user,
@@ -56,16 +60,19 @@ class certs::pulp_parent (
       mode    => '0755',
     } ->
     key_bundle { "${nodes_cert_dir}/${::certs::pulp_parent::nodes_cert}":
-      cert => Cert["${::certs::pulp_parent::hostname}-parent-cert"],
+      key_pair => Cert["${::certs::pulp_parent::hostname}-parent-cert"],
     }
 
+    Cert["${::certs::pulp_parent::hostname}-qpid-client-cert"] ~>
     key_bundle { $messaging_client_cert:
-      cert => Cert["${::certs::pulp_parent::hostname}-qpid-client-cert"],
+      key_pair => Cert["${::certs::pulp_parent::hostname}-qpid-client-cert"],
     } ~>
     file { $messaging_client_cert:
       owner   => 'apache',
       group   => 'apache',
       mode    => '0640',
     }
+
   }
+
 }

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -1,48 +1,54 @@
 # Class for handling Puppet cert configuration
 class certs::puppet (
-    $hostname    = $::certs::node_fqdn,
-    $generate    = $::certs::generate,
-    $regenerate  = $::certs::regenerate,
-    $deploy      = $::certs::deploy,
-    $ca          = $::certs::default_ca,
-    $client_cert = $::certs::params::puppet_client_cert,
-    $client_key  = $::certs::params::puppet_client_key,
-    $client_ca   = $::certs::params::puppet_client_ca
+
+  $hostname    = $::certs::node_fqdn,
+  $generate    = $::certs::generate,
+  $regenerate  = $::certs::regenerate,
+  $deploy      = $::certs::deploy,
+
+  $ca          = $::certs::default_ca,
+  $client_cert = $::certs::params::puppet_client_cert,
+  $client_key  = $::certs::params::puppet_client_key,
+  $client_ca_cert = $::certs::params::puppet_client_ca_cert
+
   ) inherits certs::params {
 
+  $puppet_client_cert_name = "${::certs::puppet::hostname}-puppet-client"
+
   # cert for authentication of puppetmaster against foreman
-  cert { "${::certs::puppet::hostname}-puppet-client":
-    hostname    => $::certs::puppet::hostname,
-    purpose     => client,
-    country     => $::certs::country,
-    state       => $::certs::state,
-    city        => $::certs::sity,
-    org         => 'FOREMAN',
-    org_unit    => 'PUPPET',
-    expiration  => $::certs::expiration,
-    ca          => $ca,
-    generate    => $generate,
-    regenerate  => $regenerate,
-    deploy      => $deploy,
+  cert { $puppet_client_cert_name:
+    hostname      => $::certs::puppet::hostname,
+    purpose       => client,
+    country       => $::certs::country,
+    state         => $::certs::state,
+    city          => $::certs::sity,
+    org           => 'FOREMAN',
+    org_unit      => 'PUPPET',
+    expiration    => $::certs::expiration,
+    ca            => $ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    deploy        => $deploy,
+    password_file => $certs::ca_key_password_file,
   }
 
   if $deploy {
+
+    Cert[$puppet_client_cert_name] ~>
     pubkey { $client_cert:
-      cert => Cert["${::certs::puppet::hostname}-puppet-client"],
-    }
-
+      key_pair => Cert[$puppet_client_cert_name],
+    } ~>
     privkey { $client_key:
-      cert => Cert["${::certs::puppet::hostname}-puppet-client"],
+      key_pair => Cert[$puppet_client_cert_name],
     } ->
-
+    pubkey { $client_ca_cert:
+      key_pair => $ca
+    } ~>
     file { $client_key:
       ensure  => file,
       owner   => 'puppet',
       mode    => '0400',
     }
 
-    pubkey { $client_ca:
-      cert => $ca,
-    }
   }
 }

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -1,53 +1,61 @@
 # Handles Qpid cert configuration
 class certs::qpid (
 
-  $hostname = $::certs::node_fqdn,
-  $generate = $::certs::generate,
+  $hostname   = $::certs::node_fqdn,
+  $generate   = $::certs::generate,
   $regenerate = $::certs::regenerate,
-  $deploy   = $::certs::deploy,
-  $ca       = $::certs::default_ca
+  $deploy     = $::certs::deploy,
+
+  $ca = $::certs::default_ca
 
   ){
 
   Exec { logoutput => 'on_failure' }
 
-  cert { "${::certs::qpid::hostname}-qpid-broker":
-    ensure      => present,
-    hostname    => $::certs::qpid::hostname,
-    country     => $::certs::country,
-    state       => $::certs::state,
-    city        => $::certs::sity,
-    org         => 'pulp',
-    org_unit    => $::certs::org_unit,
-    expiration  => $::certs::expiration,
-    ca          => $ca,
-    generate    => $generate,
-    regenerate  => $regenerate,
-    deploy      => $deploy,
+  $qpid_cert_name = "${certs::qpid::hostname}-qpid-broker"
+
+  cert { $qpid_cert_name:
+    ensure        => present,
+    hostname      => $::certs::qpid::hostname,
+    country       => $::certs::country,
+    state         => $::certs::state,
+    city          => $::certs::sity,
+    org           => 'pulp',
+    org_unit      => $::certs::org_unit,
+    expiration    => $::certs::expiration,
+    ca            => $ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    deploy        => $deploy,
+    password_file => $certs::ca_key_password_file,
   }
 
   if $deploy {
 
-    $nss_db_password_file   = $certs::nss_db_password_file
-    $ssl_pk12_password_file = $certs::ssl_pk12_password_file
-    $qpid_cert_name         = 'qpid-broker'
-    $client_cert            = "/etc/pki/katello/${qpid_cert_name}.crt"
-    $client_key             = "/etc/pki/katello/${qpid_cert_name}.key"
-    $pfx_path               = "/etc/pki/katello/${qpid_cert_name}.pfx"
+    $nss_db_password_file   = "${certs::nss_db_dir}/nss_db_password-file"
+    $client_cert            = "${certs::pki_dir}/certs/${qpid_cert_name}.crt"
+    $client_key             = "${certs::pki_dir}/private/${qpid_cert_name}.key"
+    $pfx_path               = "${certs::pki_dir}/${qpid_cert_name}.pfx"
     $nssdb_files            = ["${::certs::nss_db_dir}/cert8.db", "${::certs::nss_db_dir}/key3.db", "${::certs::nss_db_dir}/secmod.db"]
 
-    File[$certs::pki_dir] ~>
+    Cert[$qpid_cert_name] ~>
     pubkey { $client_cert:
-      cert => Cert["${::certs::qpid::hostname}-qpid-broker"]
+      key_pair => Cert["${::certs::qpid::hostname}-qpid-broker"]
     } ~>
     privkey { $client_key:
-      cert => Cert["${::certs::qpid::hostname}-qpid-broker"]
+      key_pair => Cert["${::certs::qpid::hostname}-qpid-broker"]
     } ~>
     file { $client_key:
       ensure  => file,
       owner   => 'root',
-      group   => $::certs::group,
-      mode    => '0400',
+      group   => 'apache',
+      mode    => '0440',
+    } ~>
+    file { $::certs::nss_db_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'qpidd',
+      mode   => '0755',
     } ~>
     exec { 'generate-nss-password':
       command => "openssl rand -base64 24 > ${nss_db_password_file}",
@@ -57,35 +65,22 @@ class certs::qpid (
     file { $nss_db_password_file:
       ensure  => file,
       owner   => 'root',
-      group   => $::certs::group,
+      group   => 'qpidd',
       mode    => '0640',
-    } ~>
-    exec { 'generate-pk12-password':
-      path    => '/usr/bin',
-      command => "openssl rand -base64 24 > ${ssl_pk12_password_file}",
-      creates => $ssl_pk12_password_file
-    } ~>
-    file { $ssl_pk12_password_file:
-      ensure  => file,
-      owner   => 'root',
-      group   => $::certs::group,
-      mode    => '0600',
-      require => Exec['generate-pk12-password']
-    } ~>
-    file { $::certs::nss_db_dir:
-      ensure => directory,
-      owner  => 'root',
-      group  => $::certs::group,
-      mode   => '0744',
     } ~>
     exec { 'create-nss-db':
       command => "certutil -N -d '${::certs::nss_db_dir}' -f '${nss_db_password_file}'",
       path    => '/usr/bin',
       creates => $nssdb_files,
     } ~>
+    exec { 'add-ca-cert-to-nss-db':
+      command     => "certutil -A -d '${::certs::nss_db_dir}' -n 'ca' -t 'TCu,Cu,Tuw' -a -i '${certs::ca_cert}'",
+      path        => '/usr/bin',
+      refreshonly => true,
+    } ~>
     file { $nssdb_files:
       owner   => 'root',
-      group   => $::certs::group,
+      group   => 'qpidd',
       mode    => '0640',
     } ~>
     exec { 'add-broker-cert-to-nss-db':
@@ -94,15 +89,16 @@ class certs::qpid (
       refreshonly => true,
     } ~>
     exec { 'generate-pfx-for-nss-db':
-      command     => "openssl pkcs12 -in ${client_cert} -inkey ${client_key} -export -out '${pfx_path}' -password 'file:${ssl_pk12_password_file}'",
+      command     => "openssl pkcs12 -in ${client_cert} -inkey ${client_key} -export -out '${pfx_path}' -password 'file:${nss_db_password_file}'",
       path        => '/usr/bin',
       refreshonly => true,
     } ~>
     exec { 'add-private-key-to-nss-db':
-      command     => "pk12util -i '${pfx_path}' -d '${::certs::nss_db_dir}' -w '${ssl_pk12_password_file}' -k '${nss_db_password_file}'",
+      command     => "pk12util -i '${pfx_path}' -d '${::certs::nss_db_dir}' -w '${nss_db_password_file}' -k '${nss_db_password_file}'",
       path        => '/usr/bin',
       refreshonly => true,
-    }
+    } ~>
+    Service['qpidd']
 
   }
 


### PR DESCRIPTION
cert generation and password arguments to katello-certs-tools. Provies
cleanup and simplification of where and what certs are used as well as
changing the naming conventions to reflect the fact that Katello is
the project controlling and generating the CA and certs.
