### PR TITLE
Fixing #5299: variables not used properly.

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -16,7 +16,7 @@
 # Configures rhsm on client. Called from the certificate RPM.
 #
 
-KATELLO_SERVER=<%= has_variable?("fqdn") ? fqdn : hostname %>
+KATELLO_SERVER=<%= has_variable?("fqdn") ? @fqdn : @hostname %>
 PORT=443
 <% if scope.lookupvar("katello::params::deployment") == 'katello' %>
 BASEURL=https://$KATELLO_SERVER/pulp/repos


### PR DESCRIPTION
While installing katello 'community' nighty today I noticed a few errors
related to how certain variables were being refered to in a couple of
templates:

``` bash
Variable access via 'fqdn' is deprecated. Use '@fqdn' instead.
template[/usr/share/katello-installer/modules/certs/templates/rhsm-katello-reconfigure.erb]:19
Variable access via 'fqdn' is deprecated. Use '@fqdn' instead.
template[/usr/share/katello-installer/modules/pulp/templates/etc/pulp/server.conf.erb]:40
```

This pull request should fix these variables
