### PR TITLE
fixes #5486  prefix and candlepin url incorrect for rhsm template on dev...

### DIFF
--- a/manifests/katello.pp
+++ b/manifests/katello.pp
@@ -1,5 +1,5 @@
 # Katello specific certs settings
-class certs::katello {
+class certs::katello ($hostname = $fqdn, $deployment_url = undef){
 
   $katello_www_pub_dir            = '/var/www/html/pub'
   $candlepin_consumer_name        = "${$certs::default_ca_name}-consumer-${::fqdn}"

--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -16,14 +16,12 @@
 # Configures rhsm on client. Called from the certificate RPM.
 #
 
-KATELLO_SERVER=<%= has_variable?("fqdn") ? @fqdn : @hostname %>
+KATELLO_SERVER=<%= @hostname %>
 PORT=443
-<% if scope.lookupvar("katello::params::deployment") == 'katello' %>
 BASEURL=https://$KATELLO_SERVER/pulp/repos
-<% else %>
-BASEURL=https://$KATELLO_SERVER:8088
-<% end %>
-PREFIX=/<%=scope.lookupvar("katello::params::deployment_url")%>/api
+
+DEPLOYMENT_URL=<%= @deployment_url %>
+PREFIX=$DEPLOYMENT_URL/api
 CFG=/etc/rhsm/rhsm.conf
 CFG_BACKUP=$CFG.kat-backup
 


### PR DESCRIPTION
... install
- bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1092474
- add params to katello.pp so that the appropriate prefix and candlepin url are created in the template
