### PR TITLE
Refs #6418 - Fix keytool use for Java 6 compatibility.

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -91,14 +91,14 @@ class certs::candlepin (
       unless  => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' exchanges event",
     } ~>
     exec { 'import CA into Candlepin truststore':
-      command  => "keytool -import -v -keystore ${amqp_truststore} -storepass:file ${password_file} -alias ${certs::default_ca_name} -file ${ca_cert} -noprompt",
+      command  => "keytool -import -v -keystore ${amqp_truststore} -storepass ${keystore_password} -alias ${certs::default_ca_name} -file ${ca_cert} -noprompt",
       creates  => $amqp_truststore,
     } ~>
     exec { 'import client certificate into Candlepin keystore':
       # Stupid keytool doesn't allow you to import a keypair.  You can only import a cert.  Hence, we have to
       # create the store as an PKCS12 and convert to JKS.  See http://stackoverflow.com/a/8224863
-      command  => "openssl pkcs12 -export -name amqp-client -in ${client_cert} -inkey ${client_key} -out /tmp/keystore.p12 -passout file:${password_file} && keytool -importkeystore -destkeystore ${amqp_keystore} -srckeystore /tmp/keystore.p12 -srcstoretype pkcs12 -alias amqp-client -storepass:file ${password_file} -srcstorepass:file ${password_file} -noprompt && rm /tmp/keystore.p12",
-      unless   => "keytool -list -keystore ${amqp_keystore} -storepass:file ${password_file} -alias ${certs::default_ca_name}",
+      command  => "openssl pkcs12 -export -name amqp-client -in ${client_cert} -inkey ${client_key} -out /tmp/keystore.p12 -passout file:${password_file} && keytool -importkeystore -destkeystore ${amqp_keystore} -srckeystore /tmp/keystore.p12 -srcstoretype pkcs12 -alias amqp-client -storepass ${keystore_password} -srcstorepass ${keystore_password} -noprompt && rm /tmp/keystore.p12",
+      unless   => "keytool -list -keystore ${amqp_keystore} -storepass ${keystore_password} -alias ${certs::default_ca_name}",
     } ~>
     file { $amqp_keystore:
       ensure   => file,


### PR DESCRIPTION
The :file and :env modifiers for storepass, keypass, etc. were not added
until Java 7.
