### PR TITLE
Fixes #6544 - dump event topic entitl msgs to q

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -90,6 +90,13 @@ class certs::candlepin (
       command => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' add exchange topic event --durable",
       unless  => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' exchanges event",
     } ~>
+    exec { 'create katello entitlments queue':
+      command => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' add exchange queue ${::certs::candlepin::params::katello_entitlement_queue} --durable",
+      unless  => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' exchanges ${::certs::candlepin::params::katello_entitlement_queue}",
+    } ~>
+    exec { 'bind katello entitlments queue to qpid exchange messages that deal with entitlements':
+      command => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' bind event ${::certs::candlepin::params::katello_entitlement_queue} 'entitlement.*'",
+    } ~>
     exec { 'import CA into Candlepin truststore':
       command  => "keytool -import -v -keystore ${amqp_truststore} -storepass:file ${password_file} -alias ${certs::default_ca_name} -file ${ca_cert} -noprompt",
       creates  => $amqp_truststore,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,4 +74,6 @@ class certs::params {
   # Pulp expects the node certificate to be located on this very location
   $nodes_cert_dir        = '/etc/pki/pulp/nodes'
   $nodes_cert_name       = 'node.crt'
+
+  $katello_entitlement_queue = 'katello-entitlements'
 }


### PR DESCRIPTION
This creates a queue that gets entitlement information from the event topic
so that katello can receive entitlement information.
