### PR TITLE
fixes #7007 - require pulp-server to be installed before cert work

### DIFF
--- a/manifests/pulp_parent.pp
+++ b/manifests/pulp_parent.pp
@@ -58,6 +58,7 @@ class certs::pulp_parent (
       owner   => $certs::user,
       group   => $certs::group,
       mode    => '0755',
+      require => Package['pulp-server'],
     } ->
     key_bundle { "${nodes_cert_dir}/${::certs::pulp_parent::nodes_cert_name}":
       key_pair => Cert["${::certs::pulp_parent::hostname}-parent-cert"],


### PR DESCRIPTION
otherwise /etc/pki/pulp wont exist when we try to add certs to
/etc/pki/pulp/nodes
