### PR TITLE
Fixes #7104: Ensure qpidd is restarted before qpid config is run.

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -78,8 +78,7 @@ class certs::candlepin (
       command     => "certutil -A -d '${::certs::nss_db_dir}' -n 'amqp-client' -t ',,' -a -i '${client_cert}'",
       refreshonly => true,
       subscribe   => Exec['create-nss-db'],
-      notify      => Service['qpidd'],
-    } ~>
+    } ->
     file { $amqp_store_dir:
       ensure => directory,
       owner  => 'tomcat',


### PR DESCRIPTION
On RHEL7, qpidd is not started fully before qpid-config is run due
to adding the candlepin certs to the NSS database needing to refresh
the qpidd service and qpid-config requiring that the qpidd service
be running when called.
