### PR TITLE
Fixes #7210 - make sure the Package['pulp-server'] is defined

### DIFF
--- a/manifests/capsule.pp
+++ b/manifests/capsule.pp
@@ -26,6 +26,8 @@ class certs::capsule (
   class { 'certs::apache':        hostname => $capsule_fqdn }
   class { 'certs::qpid':          hostname => $capsule_fqdn }
   class { 'certs::pulp_child':    hostname => $capsule_fqdn }
+
+  include ::pulp::install
   class { 'certs::pulp_parent':
     hostname => $parent_fqdn,
     deploy   => true,


### PR DESCRIPTION
Otherwise, capsule-certs-generate is broken
