### PR TITLE
Fixes #7239 - make sure the qpid client cert is deployed before the pulp migrations

### DIFF
--- a/manifests/capsule.pp
+++ b/manifests/capsule.pp
@@ -27,12 +27,6 @@ class certs::capsule (
   class { 'certs::qpid':          hostname => $capsule_fqdn }
   class { 'certs::pulp_child':    hostname => $capsule_fqdn }
 
-  include ::pulp::install
-  class { 'certs::pulp_parent':
-    hostname => $parent_fqdn,
-    deploy   => true,
-  }
-
   if $certs_tar {
     certs::tar_create { $certs_tar:
       subscribe => [Class['certs::puppet'],

--- a/manifests/pulp_parent.pp
+++ b/manifests/pulp_parent.pp
@@ -71,7 +71,7 @@ class certs::pulp_parent (
       owner   => 'apache',
       group   => 'apache',
       mode    => '0640',
-    }
+    } -> Class['pulp::config']
 
   }
 


### PR DESCRIPTION
Otherwise the connection to the qpid fails while running some migration file. 
This doesn't happen every-time, but I've already seen puppet ordering the
steps in this way.

Also, I've realized we don't need to include the certs::pulp_parent from the 
capsule.pp anymore. This was needed when we had separate modules for 
capsule-certe-generate (node-certs-generate back then) and we were in the 
transition phase from old installer to kafo-based one. The pulp_parent now
gets handled by the katello-intaller itself, we don't need to include that 
again for capsule-certs-generate.
