### PR TITLE
Refs #8756: Deploy the server_ca to the Capsule directories for RHSM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,3 @@ certificates are located in `/etc/pki/katello-certs-tools/` directory
 ##Development
 
 See the CONTRIBUTING guide for steps on how to make a change and get it accepted upstream.
-
->>>>>>> Refs #6736: Updates to standard layout and basic test.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,8 @@ class certs (
   $ca_key_password = cache_data('ca_key_password', generate_password())
   $ca_key_password_file = "${certs::pki_dir}/private/${default_ca_name}.pwd"
 
+  $katello_server_ca_cert = "${certs::pki_dir}/certs/${server_ca_name}.crt"
+
   class { 'certs::install': } ->
   class { 'certs::config': } ->
   file { $ca_key_password_file:
@@ -184,6 +186,17 @@ class certs (
       key_pair => $default_ca
     } ~>
     file { $ca_cert:
+      ensure => file,
+      owner  => 'root',
+      group  => $certs::group,
+      mode   => '0644',
+    }
+
+    Ca[$server_ca_name] ~>
+    pubkey { $katello_server_ca_cert:
+      key_pair => $server_ca
+    } ~>
+    file { $katello_server_ca_cert:
       ensure => file,
       owner  => 'root',
       group  => $certs::group,

--- a/manifests/katello.pp
+++ b/manifests/katello.pp
@@ -16,6 +16,7 @@ class certs::katello (
   $candlepin_consumer_name        = "katello-ca-consumer-${::fqdn}"
   $candlepin_consumer_summary     = "Subscription-manager consumer certificate for Katello instance ${::fqdn}"
   $candlepin_consumer_description = 'Consumer certificate and post installation script that configures rhsm.'
+
   file { $katello_www_pub_dir:
     ensure => directory,
     owner  => 'apache',
@@ -23,11 +24,11 @@ class certs::katello (
     mode   => '0755',
   } ->
   # Placing the CA in the pub dir for trusting by a user in their browser
-  file { "${katello_www_pub_dir}/${certs::default_ca_name}.crt":
+  file { "${katello_www_pub_dir}/${certs::server_ca_name}.crt":
     ensure => present,
-    source => "${certs::ssl_build_dir}/${certs::default_ca_name}.crt",
-    owner  => 'apache',
-    group  => 'apache',
+    source => "${certs::pki_dir}/certs/${certs::server_ca_name}.crt",
+    owner  => 'root',
+    group  => 'root',
     mode   => '0644',
   } ->
   # We need to deliver the server_ca for yum and rhsm to trust the server
@@ -36,10 +37,9 @@ class certs::katello (
     dir              => $katello_www_pub_dir,
     summary          => $candlepin_consumer_summary,
     description      => $candlepin_consumer_description,
-    files            => ["${rhsm_ca_dir}/candlepin-local.pem:644=${certs::ssl_build_dir}/${certs::default_ca_name}.crt",
-      "${rhsm_ca_dir}/katello-server-ca.pem:644 =${certs::ssl_build_dir}/${certs::server_ca_name}.crt"],
+    files            => ["${rhsm_ca_dir}/katello-server-ca.pem:644 =${certs::pki_dir}/certs/${certs::server_ca_name}.crt"],
     bootstrap_script => template('certs/rhsm-katello-reconfigure.erb'),
     alias            => $candlepin_cert_rpm_alias,
-    subscribe        => $::certs::server_ca;
+    subscribe        => $::certs::server_ca,
   }
 }


### PR DESCRIPTION
This fixes an issue where for stand alone Capsules that didn't have
access to the server_ca (since it was not deployed) the bootstrap
RPM would fail to be created. Further, this removes the unused
candlepin-local.pem which in reality was just the root CA cert.