### PR TITLE
Fixes #9204: Resolve conflict with similar cert names.

### DIFF
--- a/lib/puppet/provider/katello_ssl_tool.rb
+++ b/lib/puppet/provider/katello_ssl_tool.rb
@@ -105,9 +105,13 @@ module Puppet::Provider::KatelloSslTool
     end
 
     def rpmfile
-      rpmfile = Dir[self.build_path("#{rpmfile_base_name}*.noarch.rpm")].max_by do |file|
+      path = self.build_path("#{rpmfile_base_name}")
+      path = path + "-[0-9].*" + "noarch.rpm"
+
+      rpmfile = Dir[path].max_by do |file|
         version_from_name(file)
       end
+
       rpmfile ||= self.build_path("#{rpmfile_base_name}.noarch.rpm")
       return rpmfile
     end


### PR DESCRIPTION
If two certs have roughly the same name, one can over ride the over
during lookup for existence. For example, katello-foreman-proxy and
katello-foreman-proxy-client would have been resolved to the latter name
and then when the certs are deployed to the certs directory from
the RPMs they would not exist.