### PR TITLE
refs #9392 - pass options to foreman-rake config command correctly 

### DIFF
--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -48,7 +48,7 @@ class certs::foreman (
       mode   => '0400',
     }
 
-    $foreman_config_cmd = "${::foreman::app_root}/script/foreman-rake config\
+    $foreman_config_cmd = "${::foreman::app_root}/script/foreman-rake config --\
       -k ssl_ca_file -v '${ssl_ca_cert}'\
       -k ssl_certificate -v '${client_cert}'\
       -k ssl_priv_key -v '${client_key}'"


### PR DESCRIPTION
Reverts Katello/puppet-certs#50 - this doesn't actually work

```
[root@prometheus katello-installer]# foreman-rake config -k ssl_ca_file -v '/etc/foreman/proxy_ca.pem'      -k ssl_certificate -v '/etc/foreman/client_cert.pem'      -k ssl_priv_key -v '/etc/foreman/client_key.pem'
invalid option: -k
```

@eLobato 