### PR TITLE
Fixes #9699: Check for nssdb creation before running certutil.

### DIFF
--- a/manifests/ssltools/certutil.pp
+++ b/manifests/ssltools/certutil.pp
@@ -1,6 +1,6 @@
 # type to append cert to nssdb
 define certs::ssltools::certutil($nss_db_dir, $client_cert, $cert_name=$title, $refreshonly = true) {
-  File[$nss_db_dir] ->
+  Exec['create-nss-db'] ->
   exec { "delete ${cert_name}":
     path        => ['/bin', '/usr/bin'],
     command     => "certutil -D -d ${nss_db_dir} -n '${cert_name}'",


### PR DESCRIPTION
Switches to checking for the nssb execute that creates the actual
database instead of just the directory that contains them. This
prevents the following error on EL6:

  certutil: function failed: SEC_ERROR_LEGACY_DATABASE: The
  certificate/key database is in an unsupported format.