### PR TITLE
Fixes #9875: Better docker service restart

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -71,9 +71,14 @@ if [ -d $CA_TRUST_ANCHORS ]; then
   cp $KATELLO_CERT_DIR/$KATELLO_CERT $CA_TRUST_ANCHORS
   update-ca-trust
 
-  #restart if docker service is installed
-  service docker status >/dev/null && \
+  # restart docker if it is installed and running
+  if [ -f /usr/lib/systemd/system/docker.service ]; then
+    systemctl status docker >/dev/null && \
+    systemctl restart docker >/dev/null 2&>1
+  elif [ -f /etc/init.d/docker ]; then
+    service docker status >/dev/null && \
     service docker restart >/dev/null 2&>1
+  fi
 fi
 
 # restart goferd if it is installed and running


### PR DESCRIPTION
Improve the check for the docker service in order to restart it if
needed. Also check for systemd based system first and then fall back to
the service based utilities.