### PR TITLE
fixes #10350 - switch to qdrouterd user for certs + keys

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,7 +97,7 @@ class certs::params {
   $qpid_router_client_cert = "${pki_dir}/qpid_router_client.crt"
   $qpid_router_server_key  = "${pki_dir}/qpid_router_server.key"
   $qpid_router_client_key  = "${pki_dir}/qpid_router_client.key"
-  $qpid_router_owner       = 'qpidd'
+  $qpid_router_owner       = 'qdrouterd'
   $qpid_router_group       = 'root'
 
   $pulp_server_ca_cert   = '/etc/pki/pulp/server_ca.crt'


### PR DESCRIPTION
The latest version of the Dispatch Router runs under the qdrouterd
user instead of root as it previously did. This means the certs+keys
all need to be owned by the qdrouterd user instead of qpidd.