### PR TITLE
refs #11737 - support cnames and add localhost cname to qpid certs

### DIFF
--- a/lib/puppet/provider/cert/katello_ssl_tool.rb
+++ b/lib/puppet/provider/cert/katello_ssl_tool.rb
@@ -10,6 +10,7 @@ Puppet::Type.type(:cert).provide(:katello_ssl_tool, :parent => Puppet::Provider:
               '--server-cert-req', File.basename(req_file),
               '--server-key', File.basename(privkey),
               '--server-rpm', rpmfile_base_name ]
+
     if resource[:custom_pubkey]
       FileUtils.mkdir_p(build_path)
       FileUtils.cp(resource[:custom_pubkey], build_path(File.basename(pubkey)))
@@ -25,6 +26,15 @@ Puppet::Type.type(:cert).provide(:katello_ssl_tool, :parent => Puppet::Provider:
                    '--ca-key', ca_details[:privkey]])
       args.concat(common_args)
     end
+
+    if resource[:cname]
+      if resource[:cname].is_a?(String)
+        args << ['--set-cname', resource[:cname]]
+      else
+        args << resource[:cname].map { |cname| ['--set-cname', cname] }.flatten
+      end
+    end
+
     katello_ssl_tool(*args)
     super
   end

--- a/lib/puppet/type/certs_common.rb
+++ b/lib/puppet/type/certs_common.rb
@@ -16,6 +16,8 @@ module Certs
 
     newparam(:common_name)
 
+    newparam(:cname)
+
     newparam(:email)
 
     newparam(:country)

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -87,8 +87,8 @@ class certs::candlepin (
       mode   => '0750',
     } ~>
     exec { 'create candlepin qpid exchange':
-      command => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' add exchange topic ${certs::candlepin_qpid_exchange} --durable",
-      unless  => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' exchanges ${certs::candlepin_qpid_exchange}",
+      command => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://localhost:5671' add exchange topic ${certs::candlepin_qpid_exchange} --durable",
+      unless  => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://localhost:5671' exchanges ${certs::candlepin_qpid_exchange}",
       require => Service['qpidd'],
     } ~>
     exec { 'import CA into Candlepin truststore':

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -14,6 +14,7 @@ class certs::qpid (
   cert { $qpid_cert_name:
     ensure        => present,
     hostname      => $::certs::qpid::hostname,
+    cname         => 'localhost',
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,


### PR DESCRIPTION
This will require the user to do a `--certs-update-all` for the next upgrade, so qpid gets the new cert with the additional CN.