### PR TITLE
Pulp consumer_ca_cert is now ca_cert

### DIFF
--- a/manifests/pulp_child.pp
+++ b/manifests/pulp_child.pp
@@ -24,7 +24,7 @@ class certs::pulp_child (
   }
 
   if $deploy {
-    pubkey { $pulp::consumers_ca_cert:
+    pubkey { $pulp::ca_cert:
       key_pair => $::certs::default_ca,
     } ~>
 


### PR DESCRIPTION
The puppet-pulp 1.0 module removed the consumer_ca_cert parameter
in favor of ca_cert.