### PR TITLE
Fixes #10052 - Code to setup rhsm.conf for atomic hosts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 3
 
 gem 'rake'
 gem 'rspec-puppet', '~> 2.0'
+gem 'rspec-puppet-utils', '~> 2.0'
 gem 'puppetlabs_spec_helper', '>= 0.8.0'
 gem 'puppet-lint', '>= 1'
 gem 'puppet-lint-unquoted_string-check'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,7 @@ class certs (
   $ca_key_password_file = "${certs::pki_dir}/private/${default_ca_name}.pwd"
 
   $katello_server_ca_cert = "${certs::pki_dir}/certs/${server_ca_name}.crt"
+  $katello_default_ca_cert = "${certs::pki_dir}/certs/${default_ca_name}.crt"
 
   class { '::certs::install': } ->
   class { '::certs::config': } ->

--- a/spec/classes/certs_katello_spec.rb
+++ b/spec/classes/certs_katello_spec.rb
@@ -16,12 +16,12 @@ describe 'certs::katello' do
 
   context 'with parameters' do
     let :pre_condition do
-      "class {'certs': pki_dir => '/tmp', server_ca_name => 'foo'}"
+      "class {'certs': pki_dir => '/tmp', server_ca_name => 'server_ca', default_ca_name => 'default_ca'}"
     end
 
     describe 'with katello certs set' do
       # source format should be -> "${certs::pki_dir}/certs/${server_ca_name}.crt"
-      it { should contain_trusted_ca__ca('katello_server-host-cert').with({ :source => "/tmp/certs/foo.crt" }) }
+      it { should contain_trusted_ca__ca('katello_server-host-cert').with({ :source => "/tmp/certs/server_ca.crt" }) }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@
 #   https://github.com/katello/foreman-installer-modulesync
 
 require 'puppetlabs_spec_helper/module_spec_helper'
-
+require 'rspec-puppet'
+require 'rspec-puppet-utils'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 

--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2013 Red Hat, Inc.
+# Copyright 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -16,22 +16,26 @@
 # Configures rhsm on client. Called from the certificate RPM.
 #
 
+#copy the certificate to this variable KATELLO_SERVER_CA_DATA
+read -r -d '' KATELLO_SERVER_CA_DATA << EOM
+<%= File.exist?(scope['certs::katello_server_ca_cert']) ? File.open(scope['certs::katello_server_ca_cert']).read : "" %>
+EOM
+
+#copy the default ca certificate to this variable KATELLO_DEFAULT_CA_DATA
+read -r -d '' KATELLO_DEFAULT_CA_DATA << EOM
+<%= File.exist?(scope['certs::katello_default_ca_cert']) ? File.open(scope['certs::katello_default_ca_cert']).read : "" %>
+EOM
+
 KATELLO_SERVER=<%= @hostname %>
-KATELLO_CERT=<%= @server_ca_name %>.pem
+KATELLO_SERVER_CA_CERT=<%= @server_ca_name %>.pem
+KATELLO_DEFAULT_CA_CERT=<%= @default_ca_name %>.pem
 KATELLO_CERT_DIR=<%= @rhsm_ca_dir %>
 PORT=<%= @rhsm_port %>
-BASEURL=https://$KATELLO_SERVER/pulp/repos
 
 PREFIX=<%= @deployment_url %>
 CFG=/etc/rhsm/rhsm.conf
 CFG_BACKUP=$CFG.kat-backup
 CA_TRUST_ANCHORS=/etc/pki/ca-trust/source/anchors
-# Get version of RHSM
-RHSM_V="`rpm -q --queryformat='%{VERSION}' subscription-manager 2> /dev/null | tr . ' '`"
-if test $? != 0 ; then
-  RHSM_V="0 0 0"
-fi
-declare -a RHSM_VERSION=($RHSM_V)
 
 # exit on non-RHEL systems or when rhsm.conf is not found
 test -f $CFG || exit
@@ -40,35 +44,68 @@ type -P subscription-manager >/dev/null || type -P subscription-manager-cli >/de
 # backup configuration during the first run
 test -f $CFG_BACKUP || cp $CFG $CFG_BACKUP
 
-# configure rhsm
-# the config command was introduced in rhsm 0.96.6
-# fallback left for older versions
-if test ${RHSM_VERSION[0]:-0} -gt 0 -o ${RHSM_VERSION[1]:-0} -gt 96 -o \( ${RHSM_VERSION[1]:-0} -eq 96 -a ${RHSM_VERSION[2]:-0} -gt 6 \); then
+#create the cert
+echo "$KATELLO_SERVER_CA_DATA" > $KATELLO_CERT_DIR/$KATELLO_SERVER_CA_CERT
+chmod 644 $KATELLO_CERT_DIR/$KATELLO_SERVER_CA_CERT
+
+echo "$KATELLO_DEFAULT_CA_DATA" > $KATELLO_CERT_DIR/$KATELLO_DEFAULT_CA_CERT
+chmod 644 $KATELLO_CERT_DIR/$KATELLO_DEFAULT_CA_CERT
+
+# if not atomic machine, regular rhel then handle traditional way
+if [ -e "/run/ostree-booted" ]
+then
+  #atomic setup
+  BASEURL=https://$KATELLO_SERVER/pulp/ostree/web/
+
+  # configure rhsm
+  # the config command was introduced in rhsm 0.96.6
   subscription-manager config \
     --server.hostname="$KATELLO_SERVER" \
     --server.prefix="$PREFIX" \
     --server.port="$PORT" \
-    --rhsm.repo_ca_cert="%%(ca_cert_dir)s$KATELLO_CERT" \
+    --rhsm.repo_ca_cert="%(ca_cert_dir)s$KATELLO_SERVER_CA_CERT" \
     --rhsm.baseurl="$BASEURL"
 else
-  sed -i "s/^hostname\s*=.*/hostname = $KATELLO_SERVER/g" $CFG
-  sed -i "s/^port\s*=.*/port = $PORT/g" $CFG
-  sed -i "s|^prefix\s*=.*|prefix = $PREFIX|g" $CFG
-  sed -i "s|^repo_ca_cert\s*=.*|repo_ca_cert = %%(ca_cert_dir)s$KATELLO_CERT|g" $CFG
-  sed -i "s|^baseurl\s*=.*|baseurl=$BASEURL|g" $CFG
-fi
+  # rhel setup
+  BASEURL=https://$KATELLO_SERVER/pulp/repos
 
-if grep --quiet full_refresh_on_yum $CFG; then
-  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $CFG
-else
-  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-  sed -i "s/baseurl.*/&\n\n$full_refresh_config/g" $CFG
+  # Get version of RHSM
+  RHSM_V="`rpm -q --queryformat='%{VERSION}' subscription-manager 2> /dev/null | tr . ' '`"
+  if test $? != 0 ; then
+    RHSM_V="0 0 0"
+  fi
+  declare -a RHSM_VERSION=($RHSM_V)
+
+  # configure rhsm
+  # the config command was introduced in rhsm 0.96.6
+  # fallback left for older versions
+  if test ${RHSM_VERSION[0]:-0} -gt 0 -o ${RHSM_VERSION[1]:-0} -gt 96 -o \( ${RHSM_VERSION[1]:-0} -eq 96 -a ${RHSM_VERSION[2]:-0} -gt 6 \); then
+    subscription-manager config \
+      --server.hostname="$KATELLO_SERVER" \
+      --server.prefix="$PREFIX" \
+      --server.port="$PORT" \
+      --rhsm.repo_ca_cert="%(ca_cert_dir)s$KATELLO_SERVER_CA_CERT" \
+      --rhsm.baseurl="$BASEURL"
+  else
+    sed -i "s/^hostname\s*=.*/hostname = $KATELLO_SERVER/g" $CFG
+    sed -i "s/^port\s*=.*/port = $PORT/g" $CFG
+    sed -i "s|^prefix\s*=.*|prefix = $PREFIX|g" $CFG
+    sed -i "s|^repo_ca_cert\s*=.*|repo_ca_cert = %(ca_cert_dir)s$KATELLO_SERVER_CA_CERT|g" $CFG
+    sed -i "s|^baseurl\s*=.*|baseurl=$BASEURL|g" $CFG
+  fi
+
+  if grep --quiet full_refresh_on_yum $CFG; then
+    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $CFG
+  else
+    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+    sed -i "s/baseurl.*/&\n\n$full_refresh_config/g" $CFG
+  fi
 fi
 
 # also add the katello ca cert to the system wide ca cert store
 if [ -d $CA_TRUST_ANCHORS ]; then
   update-ca-trust enable
-  cp $KATELLO_CERT_DIR/$KATELLO_CERT $CA_TRUST_ANCHORS
+  cp $KATELLO_CERT_DIR/$KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
   update-ca-trust
 
   # restart docker if it is installed and running


### PR DESCRIPTION
Atomic hosts don't deal with Rpms. This script provides an alternative way to setup the rhsm.conf by including the cert + rpm post script as a separate entity. It also generates a katello-rhsm-atomic-consumer.tar.gz , which has this. So the user is expected download the tar gz , extract, cd into atomic and then run "katello-rhsm-atomic-consumer" script for it to setup rhsm.conf .