### PR TITLE
Fixes #13634 - Adding Katello cert to ca-trust

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,9 @@
 fixtures:
   repositories:
-    stdlib:        "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    extlib:        "git://github.com/puppet-community/puppet-extlib.git"
-    foreman:       "git://github.com/theforeman/puppet-foreman.git"
-    common:        "git://github.com/katello/puppet-common.git"
+    stdlib:            "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    extlib:            "git://github.com/puppet-community/puppet-extlib.git"
+    foreman:           "git://github.com/theforeman/puppet-foreman.git"
+    common:            "git://github.com/katello/puppet-common.git"
+    trusted_ca:        "git://github.com/evenup/evenup-trusted_ca.git"
   symlinks:
     certs: "#{source_dir}"

--- a/manifests/katello.pp
+++ b/manifests/katello.pp
@@ -18,6 +18,12 @@ class certs::katello (
   $candlepin_consumer_summary     = "Subscription-manager consumer certificate for Katello instance ${::fqdn}"
   $candlepin_consumer_description = 'Consumer certificate and post installation script that configures rhsm.'
 
+  include ::trusted_ca
+  trusted_ca::ca { 'katello_server-host-cert':
+    source  => $certs::katello_server_ca_cert,
+    require => File[$certs::katello_server_ca_cert],
+  }
+
   file { $katello_www_pub_dir:
     ensure => directory,
     owner  => 'apache',

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,10 @@
   "issues_url": "http://projects.theforeman.org/projects/katello/issues",
   "dependencies": [
     {
+      "name": "evenup-trusted_ca",
+      "version_requirement": ">= 1.0.1 < 2.0.0"
+    },
+    {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.2.0 < 5.0.0"
     },

--- a/spec/classes/certs_katello_spec.rb
+++ b/spec/classes/certs_katello_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'certs::katello' do
+  let :facts do
+    {
+      :concat_basedir             => '/tmp',
+      :interfaces                 => '',
+      :operatingsystem            => 'RedHat',
+      :operatingsystemrelease     => '6',
+      :operatingsystemmajrelease  => '6',
+      :osfamily                   => 'RedHat',
+      :fqdn                       => 'pulp.compony.net',
+      :hostname                   => 'pulp',
+    }
+  end
+
+  context 'with parameters' do
+    let :pre_condition do
+      "class {'certs': pki_dir => '/tmp', server_ca_name => 'foo'}"
+    end
+
+    describe 'with katello certs set' do
+      # source format should be -> "${certs::pki_dir}/certs/${server_ca_name}.crt"
+      it { should contain_trusted_ca__ca('katello_server-host-cert').with({ :source => "/tmp/certs/foo.crt" }) }
+    end
+  end
+end


### PR DESCRIPTION
Adding Katello Server cert to the machines local ca-trust