### PR TITLE
fix bootstrap rpm in katello_devel install

### DIFF
--- a/manifests/katello.pp
+++ b/manifests/katello.pp
@@ -48,6 +48,7 @@ class certs::katello (
     group   => 'root',
     mode    => '0755',
     content => template('certs/rhsm-katello-reconfigure.erb'),
+    require => Class['::certs'],
   } ~>
   certs_bootstrap_rpm { $candlepin_consumer_name:
     dir              => $katello_www_pub_dir,

--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -27,8 +27,8 @@ read -r -d '' KATELLO_DEFAULT_CA_DATA << EOM
 EOM
 
 KATELLO_SERVER=<%= @hostname %>
-KATELLO_SERVER_CA_CERT=<%= @server_ca_name %>.pem
-KATELLO_DEFAULT_CA_CERT=<%= @default_ca_name %>.pem
+KATELLO_SERVER_CA_CERT=<%= scope['certs::server_ca_name'] %>.pem
+KATELLO_DEFAULT_CA_CERT=<%= scope['certs::default_ca_name'] %>.pem
 KATELLO_CERT_DIR=<%= @rhsm_ca_dir %>
 PORT=<%= @rhsm_port %>
 


### PR DESCRIPTION
in a katello_devel install, the variables were not properly looked up
and the ca certificate had not been written to the filesystem yet