### PR TITLE
Fixes #13925: Use concat to build reconfigure script

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,5 +5,6 @@ fixtures:
     foreman:           "git://github.com/theforeman/puppet-foreman.git"
     common:            "git://github.com/katello/puppet-common.git"
     trusted_ca:        "git://github.com/evenup/evenup-trusted_ca.git"
+    concat:            "git://github.com/puppetlabs/puppetlabs-concat"
   symlinks:
     certs: "#{source_dir}"

--- a/manifests/katello.pp
+++ b/manifests/katello.pp
@@ -41,14 +41,9 @@ class certs::katello (
     mode    => '0644',
     require => File[$certs::katello_server_ca_cert],
   } ~>
-  # Generate the the rhsm setup script in the pub dir for rhsm setup
-  file { "${katello_www_pub_dir}/${katello_rhsm_setup_script}":
-    ensure  => file,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-    content => template('certs/rhsm-katello-reconfigure.erb'),
-    require => Class['::certs'],
+  certs::rhsm_reconfigure_script { "${katello_www_pub_dir}/${katello_rhsm_setup_script}":
+    ca_cert        => $::certs::ca_cert,
+    server_ca_cert => $::certs::katello_server_ca_cert,
   } ~>
   certs_bootstrap_rpm { $candlepin_consumer_name:
     dir              => $katello_www_pub_dir,

--- a/manifests/rhsm_reconfigure_script.pp
+++ b/manifests/rhsm_reconfigure_script.pp
@@ -1,0 +1,57 @@
+define certs::rhsm_reconfigure_script($ca_cert, $server_ca_cert) {
+
+  concat { $title:
+    owner => 'root',
+    group => 'root',
+    mode  => '0755',
+  }
+  
+  concat::fragment { "${title}+script_start":
+    target  => $title,
+    content => "#!/bin/bash\n\n",
+    order   => '01',
+  }
+  
+  concat::fragment { "${title}+default_ca_data":
+    target  => $title,
+    content => "read -r -d '' KATELLO_DEFAULT_CA_DATA << EOM\n",
+    order   => '02',
+  }
+
+  concat::fragment { "${title}+ca_cert":
+    target => $title,
+    source => $ca_cert,
+    order  => '03',
+  }
+
+  concat::fragment { "${title}+end_ca_cert":
+    target  => $title,
+    content => "EOM\n\n",
+    order   => '04',
+  }
+  
+  concat::fragment { "${title}+server_ca_data":
+    target  => $title,
+    content => "read -r -d '' KATELLO_SERVER_CA_DATA << EOM\n",
+    order   => '05',
+  }
+
+  concat::fragment { "${title}+server_ca_cert":
+    target => $title,
+    source => $server_ca_cert,
+    order  => '06',
+  }
+
+  concat::fragment { "${title}+end_server_ca_cert":
+    target  => $title,
+    content => "EOM\n\n",
+    order   => '07',
+  }
+
+  concat::fragment { "${title}+reconfigure":
+    target  => $title,
+    content => template('certs/rhsm-katello-reconfigure.erb'),
+    order   => '10',
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,10 @@
       "version_requirement": ">= 0.10.4 < 1.0.0"
     },
     {
+      "name": "puppetlabs-concat",
+      "version_requirement": ">= 1.0.0 < 3.0.0"
+    },
+    {
       "name": "theforeman-foreman",
       "version_requirement": ">= 5.0.0 < 6.0.0"
     },

--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -1,31 +1,3 @@
-#!/bin/bash
-#
-# Copyright 2016 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public License,
-# version 2 (GPLv2). There is NO WARRANTY for this software, express or
-# implied, including the implied warranties of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
-# along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-#
-# Red Hat trademarks are not licensed under GPLv2. No permission is
-# granted to use or replicate Red Hat trademarks that are incorporated
-# in this software or its documentation.
-#
-# Configures rhsm on client. Called from the certificate RPM.
-#
-
-#copy the certificate to this variable KATELLO_SERVER_CA_DATA
-read -r -d '' KATELLO_SERVER_CA_DATA << EOM
-<%= File.exist?(scope['certs::katello_server_ca_cert']) ? File.open(scope['certs::katello_server_ca_cert']).read : "" %>
-EOM
-
-#copy the default ca certificate to this variable KATELLO_DEFAULT_CA_DATA
-read -r -d '' KATELLO_DEFAULT_CA_DATA << EOM
-<%= File.exist?(scope['certs::katello_default_ca_cert']) ? File.open(scope['certs::katello_default_ca_cert']).read : "" %>
-EOM
-
 KATELLO_SERVER=<%= @hostname %>
 KATELLO_SERVER_CA_CERT=<%= scope['certs::server_ca_name'] %>.pem
 KATELLO_DEFAULT_CA_CERT=<%= scope['certs::default_ca_name'] %>.pem


### PR DESCRIPTION
On Puppet 3.6 the use of File.read in the reconfigure template
causes the certs to be empty given the template is evaluated
at the beginning. This switches to concat to build up the reconfigure
script using the source parameter to read from the cert files.