### PR TITLE
Fixes #12266: Handle last RPM sort for more than 10 bootstrap RPMs

### DIFF
--- a/lib/puppet/provider/certs_bootstrap_rpm/katello_ssl_tool.rb
+++ b/lib/puppet/provider/certs_bootstrap_rpm/katello_ssl_tool.rb
@@ -33,7 +33,17 @@ Puppet::Type.type(:certs_bootstrap_rpm).provide(:katello_ssl_tool) do
   protected
 
   def last_rpm
-    Dir.glob(File.join(resource[:dir], "#{resource[:name]}-*.noarch.rpm")).sort.last
+    rpms = Dir.glob(File.join(resource[:dir], "#{resource[:name]}-*.noarch.rpm"))
+
+    rpms = rpms.collect do |rpm|
+      rpm_split = rpm.split("#{resource[:name]}-")[1].split('.noarch.rpm')[0]
+      version = rpm_split.split('-')[0]
+      release = rpm_split.split('-')[1]
+
+      {'release' => release, 'rpm' => rpm}
+    end
+
+    rpms.sort { |a,b| a['release'].to_i <=> b['release'].to_i }.last
   end
 
   def next_release


### PR DESCRIPTION
Old method of sorting used string based comparisons which after 10
release versions fails to sort properly. This moves to a method of
comparing individual releases via integer comparison to derive the
latest boostrap RPM.