### PR TITLE
Refs #12266 - Fixes no implicit conversion of Hash into String

### DIFF
--- a/lib/puppet/provider/certs_bootstrap_rpm/katello_ssl_tool.rb
+++ b/lib/puppet/provider/certs_bootstrap_rpm/katello_ssl_tool.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:certs_bootstrap_rpm).provide(:katello_ssl_tool) do
       {'release' => release, 'rpm' => rpm}
     end
 
-    rpms.sort { |a,b| a['release'].to_i <=> b['release'].to_i }.last
+    rpms.sort { |a,b| a['release'].to_i <=> b['release'].to_i }.last['rpm']
   end
 
   def next_release


### PR DESCRIPTION
/Stage[main]/Certs::Katello/Certs_bootstrap_rpm[katello-ca-consumer-centos7-bats.example.com]: no implicit conversion of Hash into String
/usr/share/katello-installer-base/modules/certs/lib/puppet/provider/certs_bootstrap_rpm/katello_ssl_tool.rb:25:in symlink