### PR TITLE
Fixes #15538 - make sure the rpms from ssl-build are used

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -73,8 +73,9 @@ class certs::candlepin (
     privkey { $client_key:
       key_pair => Cert[$java_client_cert_name],
     } ~>
-    exec { 'candlepin-add-client-cert-to-nss-db':
-      command     => "certutil -A -d '${::certs::nss_db_dir}' -n 'amqp-client' -t ',,' -a -i '${client_cert}'",
+    certs::ssltools::certutil { 'amqp-client':
+      nss_db_dir  => $::certs::nss_db_dir,
+      client_cert => $client_cert,
       refreshonly => true,
       subscribe   => Exec['create-nss-db'],
       notify      => Service['qpidd'],

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -71,9 +71,10 @@ class certs::qpid (
       path    => '/usr/bin',
       creates => $nssdb_files,
     } ~>
-    exec { 'add-ca-cert-to-nss-db':
-      command     => "certutil -A -d '${::certs::nss_db_dir}' -n 'ca' -t 'TCu,Cu,Tuw' -a -i '${certs::ca_cert}'",
-      path        => '/usr/bin',
+    certs::ssltools::certutil { 'ca':
+      nss_db_dir  => $::certs::nss_db_dir,
+      client_cert => $::certs::ca_cert,
+      trustargs   => 'TCu,Cu,Tuw',
       refreshonly => true,
     } ~>
     file { $nssdb_files:
@@ -81,9 +82,9 @@ class certs::qpid (
       group => $certs::qpidd_group,
       mode  => '0640',
     } ~>
-    exec { 'add-broker-cert-to-nss-db':
-      command     => "certutil -A -d '${::certs::nss_db_dir}' -n 'broker' -t ',,' -a -i '${client_cert}'",
-      path        => '/usr/bin',
+    certs::ssltools::certutil { 'broker':
+      nss_db_dir  => $::certs::nss_db_dir,
+      client_cert => $client_cert,
       refreshonly => true,
     } ~>
     exec { 'generate-pfx-for-nss-db':

--- a/manifests/ssltools/certutil.pp
+++ b/manifests/ssltools/certutil.pp
@@ -1,5 +1,5 @@
 # type to append cert to nssdb
-define certs::ssltools::certutil($nss_db_dir, $client_cert, $cert_name=$title, $refreshonly = true) {
+define certs::ssltools::certutil($nss_db_dir, $client_cert, $cert_name=$title, $refreshonly = true, $trustargs = ',,') {
   Exec['create-nss-db'] ->
   exec { "delete ${cert_name}":
     path        => ['/bin', '/usr/bin'],
@@ -10,7 +10,7 @@ define certs::ssltools::certutil($nss_db_dir, $client_cert, $cert_name=$title, $
   } ->
   exec { $cert_name:
     path        => ['/bin', '/usr/bin'],
-    command     => "certutil -A -d '${nss_db_dir}' -n '${cert_name}' -t ',,' -a -i '${client_cert}'",
+    command     => "certutil -A -d '${nss_db_dir}' -n '${cert_name}' -t '${trustargs}' -a -i '${client_cert}'",
     unless      => "certutil -L -d ${nss_db_dir} | grep '${cert_name}'",
     logoutput   => true,
     refreshonly => $refreshonly,


### PR DESCRIPTION
Before this patch, we were relying on the fact that the latest rpms
are always better. However, people often try to rollback to the
previous state of ssl-build and this behavior of the certs script was
causing more troubles than benefits.

After this change, we always use the latest version we have available
in ssl-build by checking if that's what's already installed on the
system or not.

While trying to rollback to some older version of certs, I was hitting
the nssdb errors, as we were not cleaning the certs in there properly.
Therefore I've reused the resource we already had there for certutil,
to clean up certs first.

Steps to test:

  1 install katello
  2 check the certificiate of web UI
  3 `cp ~/ssl-build{,.1}`
  4 `foreman-installer --certs-update-all`
  5 check the certificiate of web UI
  6 `cp ~/ssl-build{,.2}`
  7 `rm -rf ~/ssl-build`
  8 `cp ~/ssl-build{.1,}`
  9 `foreman-installer`
  10 the certificate of the web UI should change back to the one from step 2
  11 `foreman-installer --certs-update-all`
  12 the certificate of the web UI should be different than the one from step 2 or 5