### PR TITLE
Refs #15538: Check for nssdb cert as the beginning of a line

### DIFF
--- a/manifests/ssltools/certutil.pp
+++ b/manifests/ssltools/certutil.pp
@@ -4,14 +4,14 @@ define certs::ssltools::certutil($nss_db_dir, $client_cert, $cert_name=$title, $
   exec { "delete ${cert_name}":
     path        => ['/bin', '/usr/bin'],
     command     => "certutil -D -d ${nss_db_dir} -n '${cert_name}'",
-    onlyif      => "certutil -L -d ${nss_db_dir} | grep '${cert_name}'",
+    onlyif      => "certutil -L -d ${nss_db_dir} | grep '^${cert_name}\\b'",
     logoutput   => true,
     refreshonly => $refreshonly,
   } ->
   exec { $cert_name:
     path        => ['/bin', '/usr/bin'],
     command     => "certutil -A -d '${nss_db_dir}' -n '${cert_name}' -t '${trustargs}' -a -i '${client_cert}'",
-    unless      => "certutil -L -d ${nss_db_dir} | grep '${cert_name}'",
+    unless      => "certutil -L -d ${nss_db_dir} | grep '^${cert_name}\\b'",
     logoutput   => true,
     refreshonly => $refreshonly,
   }


### PR DESCRIPTION
When using something short and non-specific like 'ca' to grep the
nssdb output, other words in the nssdb can pass the test. For example,

[root@sat-r220-02 ~]# certutil -L -d /etc/pki/katello/nssdb

Certificate Nickname                               Trust Attributes
                                                   SSL,S/MIME,JAR/XPI

amqp-client                                                  ,,
broker                                                       u,u,u

The 'ca' in 'Certificate Nickname' passes the 'grep ca' test.