### PR TITLE
Use /etc/puppet for client SSL certificates

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,7 +73,7 @@ class certs::params {
 
   $puppet_ssldir = $aio_package ? {
     true    => '/etc/puppetlabs/puppet/ssl',
-    default => '/etc/puppet/ssl'
+    default => '/etc/puppet'
   }
 
   $puppet_client_cert = "${puppet_ssldir}/client_cert.pem"


### PR DESCRIPTION
Trying a puppet 3 install, and I get this error:

```
[ERROR 2016-08-04 10:36:46 main]  Could not set 'present' on ensure: No such file or directory - /etc/puppet/ssl/client_cert.pem at 39:/usr/share/katello-installer-base/modules/certs/manifests/puppet.pp
```

Looks like I was wrong (https://github.com/Katello/puppet-certs/pull/95#issuecomment-235951864) about /etc/puppet/ssl existing, just reverting it to the original place we were storing these for puppet 3.