### PR TITLE
Bump foreman dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman-foreman",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
       "name": "katello-common",


### PR DESCRIPTION
There are other modules that require `foreman-theforeman > 6.0.0`,
which would break when this module was imported into librarian.