### PR TITLE
Modified codes to switch tar option

### DIFF
--- a/manifests/tar_extract.pp
+++ b/manifests/tar_extract.pp
@@ -12,9 +12,15 @@
 # - The certs class
 #
 define certs::tar_extract($path = $title) {
+
+  $tar_opts = $path? {
+    /.*tar$/ => '-xf',
+    default  => '-xzf',
+  }
+
   exec { "extract ${path}":
     cwd     => '/root',
     path    => ['/usr/bin', '/bin'],
-    command => "tar -xzf ${path}",
+    command => "tar ${tar_opts} ${path}",
   }
 }


### PR DESCRIPTION
certs::tar_extract option always use -xzf option even though certificate file extension is tar not tar.gz.
so I changed the code to see the extension before run tar command.