### PR TITLE
Changed tar option to determine the file is compressed or not

### DIFF
--- a/manifests/tar_extract.pp
+++ b/manifests/tar_extract.pp
@@ -15,6 +15,6 @@ define certs::tar_extract($path = $title) {
   exec { "extract ${path}":
     cwd     => '/root',
     path    => ['/usr/bin', '/bin'],
-    command => "tar -xzf ${path}",
+    command => "tar -xaf ${path}",
   }
 }


### PR DESCRIPTION
certs::tar_extract always use -xzf option even though the file was not compressed.

When I run the command below, the foreman-installer fails due to this problem.
```
foreman-installer --scenario capsule --capsule-certs-tar /root/katello-httpd-ssl-archive-capsule01.example.net-1.0-10.tar --certs-update-all
```

please change the option.

