### PR TITLE
refs #15931 - allow passing the cname parameter when generating certs

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -2,6 +2,7 @@
 class certs::apache (
 
   $hostname        = $::certs::node_fqdn,
+  $cname           = $::certs::cname,
   $generate        = $::certs::generate,
   $regenerate      = $::certs::regenerate,
   $deploy          = $::certs::deploy,
@@ -15,6 +16,7 @@ class certs::apache (
     cert { $apache_cert_name:
       ensure         => present,
       hostname       => $hostname,
+      cname          => $cname,
       generate       => $generate,
       deploy         => $deploy,
       regenerate     => $regenerate,
@@ -26,6 +28,7 @@ class certs::apache (
     cert { $apache_cert_name:
       ensure        => present,
       hostname      => $hostname,
+      cname         => $cname,
       country       => $::certs::country,
       state         => $::certs::state,
       city          => $::certs::city,

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -2,6 +2,7 @@
 class certs::candlepin (
 
   $hostname               = $::certs::node_fqdn,
+  $cname                  = $::certs::cname,
   $generate               = $::certs::generate,
   $regenerate             = $::certs::regenerate,
   $deploy                 = $::certs::deploy,
@@ -26,6 +27,7 @@ class certs::candlepin (
   cert { $java_client_cert_name:
     ensure        => present,
     hostname      => $hostname,
+    cname         => $cname,
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,

--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -2,6 +2,7 @@
 class certs::foreman (
 
   $hostname       = $::certs::node_fqdn,
+  $cname          = $::certs::cname,
   $generate       = $::certs::generate,
   $regenerate     = $::certs::regenerate,
   $deploy         = $::certs::deploy,
@@ -16,6 +17,7 @@ class certs::foreman (
   # cert for authentication of puppetmaster against foreman
   cert { $client_cert_name:
     hostname      => $::certs::foreman::hostname,
+    cname         => $::certs::foreman::cname,
     purpose       => client,
     country       => $::certs::country,
     state         => $::certs::state,

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -2,6 +2,7 @@
 class certs::foreman_proxy (
 
   $hostname            = $::certs::node_fqdn,
+  $cname               = $::certs::cname,
   $generate            = $::certs::generate,
   $regenerate          = $::certs::regenerate,
   $deploy              = $::certs::deploy,
@@ -22,6 +23,7 @@ class certs::foreman_proxy (
     cert { $proxy_cert_name:
       ensure         => present,
       hostname       => $::certs::foreman_proxy::hostname,
+      cname          => $::certs::foreman_proxy::cname,
       generate       => $generate,
       regenerate     => $regenerate,
       deploy         => $deploy,
@@ -33,6 +35,7 @@ class certs::foreman_proxy (
     # cert for ssl of foreman-proxy
     cert { $proxy_cert_name:
       hostname      => $::certs::foreman_proxy::hostname,
+      cname         => $::certs::foreman_proxy::cname,
       purpose       => server,
       country       => $::certs::country,
       state         => $::certs::state,
@@ -51,6 +54,7 @@ class certs::foreman_proxy (
   # cert for authentication of foreman_proxy against foreman
   cert { $foreman_proxy_client_cert_name:
     hostname      => $::certs::foreman_proxy::hostname,
+    cname         => $::certs::foreman_proxy::cname,
     purpose       => client,
     country       => $::certs::country,
     state         => $::certs::state,

--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -9,13 +9,17 @@
 # $foreman_proxy_fqdn::             FQDN of the foreman proxy
 #                                   type:String
 #
+# $foreman_proxy_cname::            additional names of the foreman proxy
+#                                   type:Array
+#
 # $certs_tar::                      Path to tar file with certs to generate
 #                                   type:Optional[Stdlib::Absolutepath]
 #
 class certs::foreman_proxy_content (
-  $parent_fqdn        = $fqdn,
-  $foreman_proxy_fqdn = $certs::node_fqdn,
-  $certs_tar          = $certs::params::certs_tar
+  $parent_fqdn          = $fqdn,
+  $foreman_proxy_fqdn   = $certs::node_fqdn,
+  $foreman_proxy_cname  = $certs::cname,
+  $certs_tar            = $certs::params::certs_tar
   ) inherits certs::params {
 
   # until we support again pushing the cert rpms to the Katello,
@@ -23,13 +27,13 @@ class certs::foreman_proxy_content (
   validate_present($certs_tar)
   validate_present($foreman_proxy_fqdn)
 
-  class { '::certs::puppet':        hostname => $foreman_proxy_fqdn  }
-  class { '::certs::foreman':       hostname => $foreman_proxy_fqdn }
-  class { '::certs::foreman_proxy': hostname => $foreman_proxy_fqdn }
-  class { '::certs::apache':        hostname => $foreman_proxy_fqdn }
-  class { '::certs::qpid':          hostname => $foreman_proxy_fqdn }
-  class { '::certs::qpid_router':   hostname => $foreman_proxy_fqdn }
-  class { '::certs::qpid_client':   hostname => $foreman_proxy_fqdn }
+  class { '::certs::puppet':        hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
+  class { '::certs::foreman':       hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
+  class { '::certs::foreman_proxy': hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
+  class { '::certs::apache':        hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
+  class { '::certs::qpid':          hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
+  class { '::certs::qpid_router':   hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
+  class { '::certs::qpid_client':   hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
 
   if $certs_tar {
     certs::tar_create { $certs_tar:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,10 @@
 #                         should be for
 #                         type:String
 #
+# $cname::                The alternative names of the host the generated certificates
+#                         should be for
+#                         type:array
+#
 # $server_ca_cert::       Path to the CA that issued the ssl certificates for https
 #                         if not specified, the default CA will be used
 #                         type:Optional[Stdlib::Absolutepath]
@@ -92,6 +96,7 @@ class certs (
 
   $log_dir        = $certs::params::log_dir,
   $node_fqdn      = $certs::params::node_fqdn,
+  $cname          = $certs::params::cname,
   $generate       = $certs::params::generate,
   $regenerate     = $certs::params::regenerate,
   $regenerate_ca  = $certs::params::regenerate_ca,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class certs::params {
   $ssl_build_dir = '/root/ssl-build'
 
   $node_fqdn = $::fqdn
+  $cname = []
 
   $custom_repo = false
 

--- a/manifests/pulp_client.pp
+++ b/manifests/pulp_client.pp
@@ -1,6 +1,7 @@
 # Pulp Client Certs
 class certs::pulp_client (
   $hostname    = $::certs::node_fqdn,
+  $cname       = $::certs::cname,
   $generate    = $::certs::generate,
   $regenerate  = $::certs::regenerate,
   $deploy      = $::certs::deploy,
@@ -14,6 +15,7 @@ class certs::pulp_client (
 
   cert { $client_cert_name:
     hostname      => $hostname,
+    cname         => $cname,
     common_name   => $common_name,
     purpose       => client,
     country       => $::certs::country,

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -2,6 +2,7 @@
 class certs::puppet (
 
   $hostname    = $::certs::node_fqdn,
+  $cname       = $::certs::cname,
   $generate    = $::certs::generate,
   $regenerate  = $::certs::regenerate,
   $deploy      = $::certs::deploy,
@@ -17,6 +18,7 @@ class certs::puppet (
   # cert for authentication of puppetmaster against foreman
   cert { $puppet_client_cert_name:
     hostname      => $::certs::puppet::hostname,
+    cname         => $::certs::puppet::cname,
     purpose       => client,
     country       => $::certs::country,
     state         => $::certs::state,

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -2,6 +2,7 @@
 class certs::qpid (
 
   $hostname   = $::certs::node_fqdn,
+  $cname      = $::certs::cname,
   $generate   = $::certs::generate,
   $regenerate = $::certs::regenerate,
   $deploy     = $::certs::deploy,
@@ -14,7 +15,7 @@ class certs::qpid (
   cert { $qpid_cert_name:
     ensure        => present,
     hostname      => $::certs::qpid::hostname,
-    cname         => 'localhost',
+    cname         => concat($::certs::qpid::cname, 'localhost'),
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,

--- a/manifests/qpid_client.pp
+++ b/manifests/qpid_client.pp
@@ -2,6 +2,7 @@
 class certs::qpid_client (
 
   $hostname   = $::certs::node_fqdn,
+  $cname      = $::certs::cname,
   $generate   = $::certs::generate,
   $regenerate = $::certs::regenerate,
   $deploy     = $::certs::deploy,
@@ -12,6 +13,7 @@ class certs::qpid_client (
 
   cert { "${hostname}-qpid-client-cert":
     hostname      => $hostname,
+    cname         => $cname,
     common_name   => 'pulp-qpid-client-cert',
     purpose       => client,
     country       => $::certs::country,

--- a/manifests/qpid_router.pp
+++ b/manifests/qpid_router.pp
@@ -1,6 +1,7 @@
 # Constains certs specific configurations for qpid dispatch router
 class certs::qpid_router(
   $hostname               = $::certs::node_fqdn,
+  $cname                  = $::certs::cname,
   $generate               = $::certs::generate,
   $regenerate             = $::certs::regenerate,
   $deploy                 = $::certs::deploy,
@@ -18,6 +19,7 @@ class certs::qpid_router(
   cert { $server_keypair:
     ensure        => present,
     hostname      => $hostname,
+    cname         => $cname,
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,
@@ -35,6 +37,7 @@ class certs::qpid_router(
   cert { $client_keypair:
     ensure        => present,
     hostname      => $hostname,
+    cname         => $cname,
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,


### PR DESCRIPTION
This PR does not completely fix http://projects.theforeman.org/issues/15931 aka https://bugzilla.redhat.com/show_bug.cgi?id=1160344, but it at least allows to actually generate certificates with multiple names in them which would have prevented the mentioned issue.

The `cert` resource already knows how to handle `katello-ssl-tool`s `--set-cname`, so we just have to pass the right value to it. This is done by creating a default `[]` cname parameter and passing this along to all `cert` invocations. Kafo then can override the value via the command line.