### PR TITLE
fixes #17863 - use puppet user not uid

### DIFF
--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -44,9 +44,10 @@ class certs::puppet (
       key_pair => $::certs::server_ca,
     } ~>
     file { $client_key:
-      ensure => file,
-      owner  => '52',
-      mode   => '0400',
+      ensure  => file,
+      owner   => 'puppet',
+      mode    => '0400',
+      require => Class['puppet::server::install'],
     }
 
   }


### PR DESCRIPTION
The UID is not using the assigned one:
https://tickets.puppetlabs.com/browse/SERVER-1381, so we can't do the 52
trick.  We need to require the puppet server install class to ensure the
package is installed first.