### PR TITLE
Only reference ::certs::params values in foreman_proxy_content

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -17,8 +17,8 @@
 #
 class certs::foreman_proxy_content (
   $parent_fqdn          = $fqdn,
-  $foreman_proxy_fqdn   = $certs::node_fqdn,
-  $foreman_proxy_cname  = $certs::cname,
+  $foreman_proxy_fqdn   = $certs::params::node_fqdn,
+  $foreman_proxy_cname  = $certs::params::cname,
   $certs_tar            = $certs::params::certs_tar
   ) inherits certs::params {
 


### PR DESCRIPTION
Values inside `certs` aren't available when `foreman-proxy-certs-generate` is run:

```
[root@certs certs]# foreman-proxy-certs-generate --certs-tar /root/foo.tar.gz --foreman-proxy-fqdn foo.example.com
Parameter foreman-proxy-cname invalid: nil is not a valid array
```

 so we need to get the defaults from the `params`, instead.  I can't think of a better solution.

In order to generate proxy certs with cnames the command would be:

```
foreman-proxy-certs-generate --certs-tar /root/foo.tar.gz --foreman-proxy-fqdn foo.example.com --foreman-proxy-cname foo-lb.example.com`
```
