### PR TITLE
Make variable usage and indenting consistent

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -6,11 +6,11 @@ class certs::apache (
   $generate        = $::certs::generate,
   $regenerate      = $::certs::regenerate,
   $deploy          = $::certs::deploy,
-  ) inherits certs::params {
+) inherits certs::params {
 
   $apache_cert_name = "${hostname}-apache"
-  $apache_cert = "${certs::pki_dir}/certs/katello-apache.crt"
-  $apache_key  = "${certs::pki_dir}/private/katello-apache.key"
+  $apache_cert = "${::certs::pki_dir}/certs/katello-apache.crt"
+  $apache_key  = "${::certs::pki_dir}/private/katello-apache.key"
 
   if $::certs::server_cert {
     cert { $apache_cert_name:
@@ -39,7 +39,7 @@ class certs::apache (
       generate      => $generate,
       regenerate    => $regenerate,
       deploy        => $deploy,
-      password_file => $certs::ca_key_password_file,
+      password_file => $::certs::ca_key_password_file,
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,24 +1,27 @@
 # Certs Configuration
-class certs::config {
+class certs::config (
+  $pki_dir = $::certs::pki_dir,
+  $group   = $::certs::group,
+) {
 
-  file { $certs::pki_dir:
+  file { $pki_dir:
     ensure => directory,
     owner  => 'root',
-    group  => $certs::group,
+    group  => $group,
     mode   => '0755',
   }
 
-  file { "${certs::pki_dir}/certs":
+  file { "${pki_dir}/certs":
     ensure => directory,
     owner  => 'root',
-    group  => $certs::group,
+    group  => $group,
     mode   => '0755',
   }
 
-  file { "${certs::pki_dir}/private":
+  file { "${pki_dir}/private":
     ensure => directory,
     owner  => 'root',
-    group  => $certs::group,
+    group  => $group,
     mode   => '0750',
   }
 

--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -1,6 +1,5 @@
 # Handles Foreman certs configuration
 class certs::foreman (
-
   $hostname       = $::certs::node_fqdn,
   $cname          = $::certs::cname,
   $generate       = $::certs::generate,
@@ -9,16 +8,15 @@ class certs::foreman (
   $client_cert    = $::certs::params::foreman_client_cert,
   $client_key     = $::certs::params::foreman_client_key,
   $ssl_ca_cert    = $::certs::params::foreman_ssl_ca_cert
+) inherits certs::params {
 
-  ) inherits certs::params {
-
-  $client_cert_name = "${::certs::foreman::hostname}-foreman-client"
+  $client_cert_name = "${hostname}-foreman-client"
 
   # cert for authentication of puppetmaster against foreman
   cert { $client_cert_name:
-    hostname      => $::certs::foreman::hostname,
-    cname         => $::certs::foreman::cname,
-    purpose       => client,
+    hostname      => $hostname,
+    cname         => $cname,
+    purpose       => 'client',
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,
@@ -29,7 +27,7 @@ class certs::foreman (
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $certs::ca_key_password_file,
+    password_file => $::certs::ca_key_password_file,
   }
 
   if $deploy {

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -1,6 +1,5 @@
 # Handles Foreman Proxy cert configuration
 class certs::foreman_proxy (
-
   $hostname            = $::certs::node_fqdn,
   $cname               = $::certs::cname,
   $generate            = $::certs::generate,
@@ -12,18 +11,17 @@ class certs::foreman_proxy (
   $foreman_ssl_cert    = $::certs::params::foreman_proxy_foreman_ssl_cert,
   $foreman_ssl_key     = $::certs::params::foreman_proxy_foreman_ssl_key,
   $foreman_ssl_ca_cert = $::certs::params::foreman_proxy_foreman_ssl_ca_cert
+) inherits certs::params {
 
-  ) inherits certs::params {
-
-  $proxy_cert_name = "${::certs::foreman_proxy::hostname}-foreman-proxy"
-  $foreman_proxy_client_cert_name = "${::certs::foreman_proxy::hostname}-foreman-proxy-client"
-  $foreman_proxy_ssl_client_bundle = "${certs::pki_dir}/private/${foreman_proxy_client_cert_name}-bundle.pem"
+  $proxy_cert_name = "${hostname}-foreman-proxy"
+  $foreman_proxy_client_cert_name = "${hostname}-foreman-proxy-client"
+  $foreman_proxy_ssl_client_bundle = "${::certs::pki_dir}/private/${foreman_proxy_client_cert_name}-bundle.pem"
 
   if $::certs::server_cert {
     cert { $proxy_cert_name:
       ensure         => present,
-      hostname       => $::certs::foreman_proxy::hostname,
-      cname          => $::certs::foreman_proxy::cname,
+      hostname       => $hostname,
+      cname          => $cname,
       generate       => $generate,
       regenerate     => $regenerate,
       deploy         => $deploy,
@@ -34,9 +32,9 @@ class certs::foreman_proxy (
   } else {
     # cert for ssl of foreman-proxy
     cert { $proxy_cert_name:
-      hostname      => $::certs::foreman_proxy::hostname,
-      cname         => $::certs::foreman_proxy::cname,
-      purpose       => server,
+      hostname      => $hostname,
+      cname         => $cname,
+      purpose       => 'server',
       country       => $::certs::country,
       state         => $::certs::state,
       city          => $::certs::city,
@@ -47,15 +45,15 @@ class certs::foreman_proxy (
       generate      => $generate,
       regenerate    => $regenerate,
       deploy        => $deploy,
-      password_file => $certs::ca_key_password_file,
+      password_file => $::certs::ca_key_password_file,
     }
   }
 
   # cert for authentication of foreman_proxy against foreman
   cert { $foreman_proxy_client_cert_name:
-    hostname      => $::certs::foreman_proxy::hostname,
-    cname         => $::certs::foreman_proxy::cname,
-    purpose       => client,
+    hostname      => $hostname,
+    cname         => $cname,
+    purpose       => 'client',
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,
@@ -66,7 +64,7 @@ class certs::foreman_proxy (
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $certs::ca_key_password_file,
+    password_file => $::certs::ca_key_password_file,
   }
 
   if $deploy {
@@ -81,13 +79,13 @@ class certs::foreman_proxy (
       notify   => Service['foreman-proxy'],
     } ->
     pubkey { $proxy_ca_cert:
-      key_pair => $certs::default_ca,
+      key_pair => $::certs::default_ca,
       notify   => Service['foreman-proxy'],
     } ~>
     file { $proxy_key:
       ensure => file,
       owner  => 'foreman-proxy',
-      group  => $certs::group,
+      group  => $::certs::group,
       mode   => '0400',
     } ~>
     Service['foreman-proxy']

--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -16,11 +16,11 @@
 #                                   type:Optional[Stdlib::Absolutepath]
 #
 class certs::foreman_proxy_content (
-  $parent_fqdn          = $fqdn,
-  $foreman_proxy_fqdn   = $certs::params::node_fqdn,
-  $foreman_proxy_cname  = $certs::params::cname,
-  $certs_tar            = $certs::params::certs_tar
-  ) inherits certs::params {
+  $parent_fqdn          = $::fqdn,
+  $foreman_proxy_fqdn   = $::certs::params::node_fqdn,
+  $foreman_proxy_cname  = $::certs::params::cname,
+  $certs_tar            = $::certs::params::certs_tar
+) inherits certs::params {
 
   # until we support again pushing the cert rpms to the Katello,
   # make sure the certs_tar path is present

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 # Certs Installation
 class certs::install {
 
-  package{['katello-certs-tools']:
+  package { 'katello-certs-tools':
     ensure  => installed,
   }
 

--- a/manifests/katello.pp
+++ b/manifests/katello.pp
@@ -22,8 +22,8 @@ class certs::katello (
 
   include ::trusted_ca
   trusted_ca::ca { 'katello_server-host-cert':
-    source  => $certs::katello_server_ca_cert,
-    require => File[$certs::katello_server_ca_cert],
+    source  => $::certs::katello_server_ca_cert,
+    require => File[$::certs::katello_server_ca_cert],
   }
 
   file { $katello_www_pub_dir:
@@ -33,13 +33,13 @@ class certs::katello (
     mode   => '0755',
   } ->
   # Placing the CA in the pub dir for trusting by a user in their browser
-  file { "${katello_www_pub_dir}/${certs::server_ca_name}.crt":
+  file { "${katello_www_pub_dir}/${::certs::server_ca_name}.crt":
     ensure  => file,
-    source  => $certs::katello_server_ca_cert,
+    source  => $::certs::katello_server_ca_cert,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    require => File[$certs::katello_server_ca_cert],
+    require => File[$::certs::katello_server_ca_cert],
   } ~>
   certs::rhsm_reconfigure_script { "${katello_www_pub_dir}/${katello_rhsm_setup_script}":
     ca_cert        => $::certs::ca_cert,

--- a/manifests/pulp_client.pp
+++ b/manifests/pulp_client.pp
@@ -40,7 +40,7 @@ class certs::pulp_client (
       key_pair => Cert[$client_cert_name],
     } ~>
     file { $client_key:
-      group => $certs::group,
+      group => $::certs::group,
       owner => 'root',
       mode  => '0440',
     }

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -1,6 +1,5 @@
 # Class for handling Puppet cert configuration
 class certs::puppet (
-
   $hostname    = $::certs::node_fqdn,
   $cname       = $::certs::cname,
   $generate    = $::certs::generate,
@@ -10,16 +9,15 @@ class certs::puppet (
   $client_cert = $::certs::params::puppet_client_cert,
   $client_key  = $::certs::params::puppet_client_key,
   $ssl_ca_cert = $::certs::params::puppet_ssl_ca_cert
+) inherits certs::params {
 
-  ) inherits certs::params {
-
-  $puppet_client_cert_name = "${::certs::puppet::hostname}-puppet-client"
+  $puppet_client_cert_name = "${hostname}-puppet-client"
 
   # cert for authentication of puppetmaster against foreman
   cert { $puppet_client_cert_name:
-    hostname      => $::certs::puppet::hostname,
-    cname         => $::certs::puppet::cname,
-    purpose       => client,
+    hostname      => $hostname,
+    cname         => $cname,
+    purpose       => 'client',
     country       => $::certs::country,
     state         => $::certs::state,
     city          => $::certs::city,
@@ -30,11 +28,11 @@ class certs::puppet (
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $certs::ca_key_password_file,
+    password_file => $::certs::ca_key_password_file,
   }
 
   if $deploy {
-    file { "${certs::pki_dir}/puppet":
+    file { "${::certs::pki_dir}/puppet":
       ensure  => directory,
       owner   => 'puppet',
       mode    => '0700',

--- a/manifests/qpid_client.pp
+++ b/manifests/qpid_client.pp
@@ -7,9 +7,8 @@ class certs::qpid_client (
   $regenerate = $::certs::regenerate,
   $deploy     = $::certs::deploy,
 
-  $messaging_client_cert = $certs::params::messaging_client_cert
-
-  ) {
+  $messaging_client_cert = $::certs::messaging_client_cert,
+) {
 
   cert { "${hostname}-qpid-client-cert":
     hostname      => $hostname,
@@ -26,7 +25,7 @@ class certs::qpid_client (
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $certs::ca_key_password_file,
+    password_file => $::certs::ca_key_password_file,
   }
 
   if $deploy {

--- a/manifests/qpid_router.pp
+++ b/manifests/qpid_router.pp
@@ -30,8 +30,8 @@ class certs::qpid_router(
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    purpose       => server,
-    password_file => $certs::ca_key_password_file,
+    purpose       => 'server',
+    password_file => $::certs::ca_key_password_file,
   }
 
   cert { $client_keypair:
@@ -48,8 +48,8 @@ class certs::qpid_router(
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    purpose       => client,
-    password_file => $certs::ca_key_password_file,
+    purpose       => 'client',
+    password_file => $::certs::ca_key_password_file,
   }
 
   if $deploy {

--- a/manifests/tar_create.pp
+++ b/manifests/tar_create.pp
@@ -9,13 +9,12 @@
 # $foreman_proxy_fqdn::         FQDN of the foreman proxy
 #
 define certs::tar_create(
-    $path               = $title,
-    $foreman_proxy_fqdn = $::certs::foreman_proxy_content::foreman_proxy_fqdn,
+  $path               = $title,
+  $foreman_proxy_fqdn = $::certs::foreman_proxy_content::foreman_proxy_fqdn,
 ) {
-
-    exec { "generate ${path}":
-        cwd     => '/root',
-        path    => ['/usr/bin', '/bin'],
-        command => "tar -czf ${path} ssl-build/*.noarch.rpm ssl-build/${foreman_proxy_fqdn}/*.noarch.rpm",
-    }
+  exec { "generate ${path}":
+    cwd     => '/root',
+    path    => ['/usr/bin', '/bin'],
+    command => "tar -czf ${path} ssl-build/*.noarch.rpm ssl-build/${foreman_proxy_fqdn}/*.noarch.rpm",
+  }
 }


### PR DESCRIPTION
* Use the absolute $::certs::
* Use local variables where possible
* Correct indenting