### PR TITLE
Allow newer versions of dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,10 @@
 fixtures:
   repositories:
     stdlib:            "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    extlib:
-      repo: 'https://github.com/puppet-community/puppet-extlib'
-      ref:  'v0.11.3'
+    extlib:            "https://github.com/puppet-community/puppet-extlib"
     foreman:           "https://github.com/theforeman/puppet-foreman.git"
     common:            "https://github.com/katello/puppet-common.git"
-    trusted_ca:        "https://github.com/evenup/evenup-trusted_ca.git"
+    trusted_ca:        "https://github.com/jlambert121/jlambert121-trusted_ca"
     concat:            "https://github.com/puppetlabs/puppetlabs-concat"
     apache:            "https://github.com/puppetlabs/puppetlabs-apache"
     puppet:            "https://github.com/theforeman/puppet-puppet"

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "http://projects.theforeman.org/projects/katello/issues",
   "dependencies": [
     {
-      "name": "evenup-trusted_ca",
+      "name": "jlambert121-trusted_ca",
       "version_requirement": ">= 1.0.1 < 2.0.0"
     },
     {
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet-extlib",
-      "version_requirement": ">= 0.10.4 < 1.0.0"
+      "version_requirement": ">= 0.10.4 < 2.0.0"
     },
     {
       "name": "puppetlabs-concat",


### PR DESCRIPTION
* puppet-extlib version 1.x has no incompatiblities compared to 0.x.
* evenup-trusted_ca was transfered to jlambert121-trusted_ca.