### PR TITLE
classes inherit from init

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,18 +1,30 @@
 # Certs configurations for Apache
 class certs::apache (
-
-  $hostname        = $::certs::node_fqdn,
-  $cname           = $::certs::cname,
-  $generate        = $::certs::generate,
-  $regenerate      = $::certs::regenerate,
-  $deploy          = $::certs::deploy,
-) inherits certs::params {
+  $hostname             = $::certs::node_fqdn,
+  $cname                = $::certs::cname,
+  $generate             = $::certs::generate,
+  $regenerate           = $::certs::regenerate,
+  $deploy               = $::certs::deploy,
+  $pki_dir              = $::certs::pki_dir,
+  $server_cert          = $::certs::server_cert,
+  $server_key           = $::certs::server_key,
+  $server_cert_req      = $::certs::server_cert_req,
+  $country              = $::certs::country,
+  $state                = $::certs::state,
+  $city                 = $::certs::city,
+  $org                  = $::certs::org,
+  $org_unit             = $::certs::org_unit,
+  $expiration           = $::certs::expiration,
+  $default_ca           = $::certs::default_ca,
+  $ca_key_password_file = $::certs::ca_key_password_file,
+  $group                = $::certs::group,
+) inherits certs {
 
   $apache_cert_name = "${hostname}-apache"
-  $apache_cert = "${::certs::pki_dir}/certs/katello-apache.crt"
-  $apache_key  = "${::certs::pki_dir}/private/katello-apache.key"
+  $apache_cert = "${pki_dir}/certs/katello-apache.crt"
+  $apache_key  = "${pki_dir}/private/katello-apache.key"
 
-  if $::certs::server_cert {
+  if $server_cert {
     cert { $apache_cert_name:
       ensure         => present,
       hostname       => $hostname,
@@ -20,26 +32,26 @@ class certs::apache (
       generate       => $generate,
       deploy         => $deploy,
       regenerate     => $regenerate,
-      custom_pubkey  => $::certs::server_cert,
-      custom_privkey => $::certs::server_key,
-      custom_req     => $::certs::server_cert_req,
+      custom_pubkey  => $server_cert,
+      custom_privkey => $server_key,
+      custom_req     => $server_cert_req,
     }
   } else {
     cert { $apache_cert_name:
       ensure        => present,
       hostname      => $hostname,
       cname         => $cname,
-      country       => $::certs::country,
-      state         => $::certs::state,
-      city          => $::certs::city,
-      org           => $::certs::org,
-      org_unit      => $::certs::org_unit,
-      expiration    => $::certs::expiration,
-      ca            => $::certs::default_ca,
+      country       => $country,
+      state         => $state,
+      city          => $city,
+      org           => $org,
+      org_unit      => $org_unit,
+      expiration    => $expiration,
+      ca            => $default_ca,
       generate      => $generate,
       regenerate    => $regenerate,
       deploy        => $deploy,
-      password_file => $::certs::ca_key_password_file,
+      password_file => $ca_key_password_file,
     }
   }
 
@@ -53,7 +65,7 @@ class certs::apache (
       manage_key => true,
       key_owner  => $::apache::user,
       key_mode   => '0400',
-      key_group  => $::certs::group,
+      key_group  => $group,
       cert_file  => $apache_cert,
       notify     => Service['httpd'],
     }

--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -1,13 +1,20 @@
 # Handles Foreman certs configuration
 class certs::foreman (
-  $hostname       = $::certs::node_fqdn,
-  $cname          = $::certs::cname,
-  $generate       = $::certs::generate,
-  $regenerate     = $::certs::regenerate,
-  $deploy         = $::certs::deploy,
-  $client_cert    = $::certs::params::foreman_client_cert,
-  $client_key     = $::certs::params::foreman_client_key,
-  $ssl_ca_cert    = $::certs::params::foreman_ssl_ca_cert
+  $hostname              = $::certs::node_fqdn,
+  $cname                 = $::certs::cname,
+  $generate              = $::certs::generate,
+  $regenerate            = $::certs::regenerate,
+  $deploy                = $::certs::deploy,
+  $client_cert           = $::certs::params::foreman_client_cert,
+  $client_key            = $::certs::params::foreman_client_key,
+  $ssl_ca_cert           = $::certs::params::foreman_ssl_ca_cert,
+  $country               = $::certs::country,
+  $state                 = $::certs::state,
+  $city                  = $::certs::city,
+  $expiration            = $::certs::expiration,
+  $default_ca            = $::certs::default_ca,
+  $ca_key_password_file  = $::certs::ca_key_password_file,
+  $server_ca             = $::certs::server_ca,
 ) inherits certs::params {
 
   $client_cert_name = "${hostname}-foreman-client"
@@ -17,17 +24,17 @@ class certs::foreman (
     hostname      => $hostname,
     cname         => $cname,
     purpose       => 'client',
-    country       => $::certs::country,
-    state         => $::certs::state,
-    city          => $::certs::city,
+    country       => $country,
+    state         => $state,
+    city          => $city,
     org           => 'FOREMAN',
     org_unit      => 'PUPPET',
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   if $deploy {
@@ -40,7 +47,7 @@ class certs::foreman (
       cert_file  => $client_cert,
     } ->
     pubkey { $ssl_ca_cert:
-      key_pair => $::certs::server_ca,
+      key_pair => $server_ca,
     }
   }
 }

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -1,23 +1,35 @@
 # Handles Foreman Proxy cert configuration
 class certs::foreman_proxy (
-  $hostname            = $::certs::node_fqdn,
-  $cname               = $::certs::cname,
-  $generate            = $::certs::generate,
-  $regenerate          = $::certs::regenerate,
-  $deploy              = $::certs::deploy,
-  $proxy_cert          = $::certs::params::foreman_proxy_cert,
-  $proxy_key           = $::certs::params::foreman_proxy_key,
-  $proxy_ca_cert       = $::certs::params::foreman_proxy_ca_cert,
-  $foreman_ssl_cert    = $::certs::params::foreman_proxy_foreman_ssl_cert,
-  $foreman_ssl_key     = $::certs::params::foreman_proxy_foreman_ssl_key,
-  $foreman_ssl_ca_cert = $::certs::params::foreman_proxy_foreman_ssl_ca_cert
-) inherits certs::params {
+  $hostname             = $::certs::node_fqdn,
+  $cname                = $::certs::cname,
+  $generate             = $::certs::generate,
+  $regenerate           = $::certs::regenerate,
+  $deploy               = $::certs::deploy,
+  $proxy_cert           = $::certs::params::foreman_proxy_cert,
+  $proxy_key            = $::certs::params::foreman_proxy_key,
+  $proxy_ca_cert        = $::certs::params::foreman_proxy_ca_cert,
+  $foreman_ssl_cert     = $::certs::params::foreman_proxy_foreman_ssl_cert,
+  $foreman_ssl_key      = $::certs::params::foreman_proxy_foreman_ssl_key,
+  $foreman_ssl_ca_cert  = $::certs::params::foreman_proxy_foreman_ssl_ca_cert,
+  $pki_dir              = $::certs::pki_dir,
+  $server_ca            = $::certs::server_ca,
+  $server_cert          = $::certs::server_cert,
+  $server_key           = $::certs::server_key,
+  $server_cert_req      = $::certs::server_cert_req,
+  $country              = $::certs::country,
+  $state                = $::certs::state,
+  $city                 = $::certs::city,
+  $expiration           = $::certs::expiration,
+  $default_ca           = $::certs::default_ca,
+  $ca_key_password_file = $::certs::ca_key_password_file,
+  $group                = $::certs::group,
+) inherits certs {
 
   $proxy_cert_name = "${hostname}-foreman-proxy"
   $foreman_proxy_client_cert_name = "${hostname}-foreman-proxy-client"
-  $foreman_proxy_ssl_client_bundle = "${::certs::pki_dir}/private/${foreman_proxy_client_cert_name}-bundle.pem"
+  $foreman_proxy_ssl_client_bundle = "${pki_dir}/private/${foreman_proxy_client_cert_name}-bundle.pem"
 
-  if $::certs::server_cert {
+  if $server_cert {
     cert { $proxy_cert_name:
       ensure         => present,
       hostname       => $hostname,
@@ -25,9 +37,9 @@ class certs::foreman_proxy (
       generate       => $generate,
       regenerate     => $regenerate,
       deploy         => $deploy,
-      custom_pubkey  => $::certs::server_cert,
-      custom_privkey => $::certs::server_key,
-      custom_req     => $::certs::server_cert_req,
+      custom_pubkey  => $server_cert,
+      custom_privkey => $server_key,
+      custom_req     => $server_cert_req,
     }
   } else {
     # cert for ssl of foreman-proxy
@@ -35,17 +47,17 @@ class certs::foreman_proxy (
       hostname      => $hostname,
       cname         => $cname,
       purpose       => 'server',
-      country       => $::certs::country,
-      state         => $::certs::state,
-      city          => $::certs::city,
+      country       => $country,
+      state         => $state,
+      city          => $city,
       org           => 'FOREMAN',
       org_unit      => 'SMART_PROXY',
-      expiration    => $::certs::expiration,
-      ca            => $::certs::default_ca,
+      expiration    => $expiration,
+      ca            => $default_ca,
       generate      => $generate,
       regenerate    => $regenerate,
       deploy        => $deploy,
-      password_file => $::certs::ca_key_password_file,
+      password_file => $ca_key_password_file,
     }
   }
 
@@ -54,17 +66,17 @@ class certs::foreman_proxy (
     hostname      => $hostname,
     cname         => $cname,
     purpose       => 'client',
-    country       => $::certs::country,
-    state         => $::certs::state,
-    city          => $::certs::city,
+    country       => $country,
+    state         => $state,
+    city          => $city,
     org           => 'FOREMAN',
     org_unit      => 'FOREMAN_PROXY',
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   if $deploy {
@@ -75,11 +87,11 @@ class certs::foreman_proxy (
       manage_key => true,
       key_owner  => 'foreman-proxy',
       key_mode   => '0400',
-      key_group  => $::certs::group,
+      key_group  => $group,
       cert_file  => $proxy_cert,
     } ->
     pubkey { $proxy_ca_cert:
-      key_pair => $::certs::default_ca,
+      key_pair => $default_ca,
     }
 
     certs::keypair { 'foreman_proxy_client':
@@ -91,7 +103,7 @@ class certs::foreman_proxy (
       cert_file  => $foreman_ssl_cert,
     } ->
     pubkey { $foreman_ssl_ca_cert:
-      key_pair => $::certs::server_ca,
+      key_pair => $server_ca,
     } ~>
     key_bundle { $foreman_proxy_ssl_client_bundle:
       key_pair => Cert[$foreman_proxy_client_cert_name],

--- a/manifests/pulp_client.pp
+++ b/manifests/pulp_client.pp
@@ -6,12 +6,21 @@ class certs::pulp_client (
   $regenerate  = $::certs::regenerate,
   $deploy      = $::certs::deploy,
   $common_name = 'admin',
-) {
+  $pki_dir      = $::certs::pki_dir,
+  $ca_cert      = $::certs::ca_cert,
+  $country                 = $::certs::country,
+  $state                   = $::certs::state,
+  $city                    = $::certs::city,
+  $expiration           = $::certs::expiration,
+  $default_ca           = $::certs::default_ca,
+  $ca_key_password_file    = $::certs::ca_key_password_file,
+  $group                   = $::certs::group,
+) inherits certs {
 
   $client_cert_name = 'pulp-client'
-  $client_cert      = "${::certs::pki_dir}/certs/${client_cert_name}.crt"
-  $client_key       = "${::certs::pki_dir}/private/${client_cert_name}.key"
-  $ssl_ca_cert      = $::certs::ca_cert
+  $client_cert      = "${pki_dir}/certs/${client_cert_name}.crt"
+  $client_key       = "${pki_dir}/private/${client_cert_name}.key"
+  $ssl_ca_cert      = $ca_cert
 
   cert { $client_cert_name:
     hostname      => $hostname,
@@ -23,12 +32,12 @@ class certs::pulp_client (
     city          => $::certs::city,
     org           => 'PULP',
     org_unit      => 'NODES',
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   if $deploy {
@@ -36,7 +45,7 @@ class certs::pulp_client (
       key_pair   => $client_cert_name,
       key_file   => $client_key,
       manage_key => true,
-      key_group  => $::certs::group,
+      key_group  => $group,
       key_owner  => 'root',
       key_mode   => '0440',
       cert_file  => $client_cert,

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -1,15 +1,25 @@
 # Class for handling Puppet cert configuration
 class certs::puppet (
-  $hostname    = $::certs::node_fqdn,
-  $cname       = $::certs::cname,
-  $generate    = $::certs::generate,
-  $regenerate  = $::certs::regenerate,
-  $deploy      = $::certs::deploy,
+  $hostname             = $::certs::node_fqdn,
+  $cname                = $::certs::cname,
+  $generate             = $::certs::generate,
+  $regenerate           = $::certs::regenerate,
+  $deploy               = $::certs::deploy,
 
-  $client_cert = $::certs::params::puppet_client_cert,
-  $client_key  = $::certs::params::puppet_client_key,
-  $ssl_ca_cert = $::certs::params::puppet_ssl_ca_cert
-) inherits certs::params {
+  $client_cert          = $::certs::puppet_client_cert,
+  $client_key           = $::certs::puppet_client_key,
+  $ssl_ca_cert          = $::certs::puppet_ssl_ca_cert,
+
+  $country              = $::certs::country,
+  $state                = $::certs::state,
+  $city                 = $::certs::city,
+  $expiration           = $::certs::expiration,
+  $default_ca           = $::certs::default_ca,
+  $ca_key_password_file = $::certs::ca_key_password_file,
+  $server_ca            = $::certs::server_ca,
+
+  $pki_dir              = $::certs::pki_dir,
+) inherits certs {
 
   $puppet_client_cert_name = "${hostname}-puppet-client"
 
@@ -18,21 +28,21 @@ class certs::puppet (
     hostname      => $hostname,
     cname         => $cname,
     purpose       => 'client',
-    country       => $::certs::country,
-    state         => $::certs::state,
-    city          => $::certs::city,
+    country       => $country,
+    state         => $state,
+    city          => $city,
     org           => 'FOREMAN',
     org_unit      => 'PUPPET',
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   if $deploy {
-    file { "${::certs::pki_dir}/puppet":
+    file { "${pki_dir}/puppet":
       ensure  => directory,
       owner   => 'puppet',
       mode    => '0700',
@@ -50,7 +60,7 @@ class certs::puppet (
       cert_mode   => '0400',
     } ->
     pubkey { $ssl_ca_cert:
-      key_pair => $::certs::server_ca,
+      key_pair => $server_ca,
     } ->
     file { $ssl_ca_cert:
       ensure => file,

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -1,11 +1,22 @@
 # Handles Qpid cert configuration
 class certs::qpid (
-  $hostname   = $::certs::node_fqdn,
-  $cname      = $::certs::cname,
-  $generate   = $::certs::generate,
-  $regenerate = $::certs::regenerate,
-  $deploy     = $::certs::deploy,
-) {
+  $hostname             = $::certs::node_fqdn,
+  $cname                = $::certs::cname,
+  $generate             = $::certs::generate,
+  $regenerate           = $::certs::regenerate,
+  $deploy               = $::certs::deploy,
+  $country              = $::certs::country,
+  $state                = $::certs::state,
+  $city                 = $::certs::city,
+  $org_unit             = $::certs::org_unit,
+  $expiration           = $::certs::expiration,
+  $default_ca           = $::certs::default_ca,
+  $ca_key_password_file = $::certs::ca_key_password_file,
+  $pki_dir              = $::certs::pki_dir,
+  $nss_db_dir           = $::certs::nss_db_dir,
+  $ca_cert              = $::certs::ca_cert,
+  $qpidd_group          = $::certs::qpidd_group,
+) inherits certs {
 
   Exec { logoutput => 'on_failure' }
 
@@ -15,46 +26,46 @@ class certs::qpid (
     ensure        => present,
     hostname      => $hostname,
     cname         => concat($cname, 'localhost'),
-    country       => $::certs::country,
-    state         => $::certs::state,
-    city          => $::certs::city,
+    country       => $country,
+    state         => $state,
+    city          => $city,
     org           => 'pulp',
-    org_unit      => $::certs::org_unit,
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    org_unit      => $org_unit,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   if $deploy {
     include ::certs::ssltools::nssdb
     $nss_db_password_file = $::certs::ssltools::nssdb::nss_db_password_file
 
-    $client_cert            = "${::certs::pki_dir}/certs/${qpid_cert_name}.crt"
-    $client_key             = "${::certs::pki_dir}/private/${qpid_cert_name}.key"
-    $pfx_path               = "${::certs::pki_dir}/${qpid_cert_name}.pfx"
+    $client_cert            = "${pki_dir}/certs/${qpid_cert_name}.crt"
+    $client_key             = "${pki_dir}/private/${qpid_cert_name}.key"
+    $pfx_path               = "${pki_dir}/${qpid_cert_name}.pfx"
 
     certs::keypair { 'qpid':
       key_pair   => $qpid_cert_name,
       key_file   => $client_key,
       manage_key => true,
       key_owner  => 'root',
-      key_group  => $::certs::qpidd_group,
+      key_group  => $qpidd_group,
       key_mode   => '0440',
       cert_file  => $client_cert,
     } ~>
     Class['::certs::ssltools::nssdb'] ~>
     certs::ssltools::certutil { 'ca':
-      nss_db_dir  => $::certs::nss_db_dir,
-      client_cert => $::certs::ca_cert,
+      nss_db_dir  => $nss_db_dir,
+      client_cert => $ca_cert,
       trustargs   => 'TCu,Cu,Tuw',
       refreshonly => true,
       subscribe   => Pubkey[$::certs::ca_cert],
     } ~>
     certs::ssltools::certutil { 'broker':
-      nss_db_dir  => $::certs::nss_db_dir,
+      nss_db_dir  => $nss_db_dir,
       client_cert => $client_cert,
       refreshonly => true,
       subscribe   => Pubkey[$client_cert],
@@ -65,7 +76,7 @@ class certs::qpid (
       refreshonly => true,
     } ~>
     exec { 'add-private-key-to-nss-db':
-      command     => "pk12util -i '${pfx_path}' -d '${::certs::nss_db_dir}' -w '${nss_db_password_file}' -k '${nss_db_password_file}'",
+      command     => "pk12util -i '${pfx_path}' -d '${nss_db_dir}' -w '${nss_db_password_file}' -k '${nss_db_password_file}'",
       path        => '/usr/bin',
       refreshonly => true,
     }

--- a/manifests/qpid_client.pp
+++ b/manifests/qpid_client.pp
@@ -1,14 +1,21 @@
 # Pulp Master Certs configuration
 class certs::qpid_client (
-
-  $hostname   = $::certs::node_fqdn,
-  $cname      = $::certs::cname,
-  $generate   = $::certs::generate,
-  $regenerate = $::certs::regenerate,
-  $deploy     = $::certs::deploy,
+  $hostname              = $::certs::node_fqdn,
+  $cname                 = $::certs::cname,
+  $generate              = $::certs::generate,
+  $regenerate            = $::certs::regenerate,
+  $deploy                = $::certs::deploy,
 
   $messaging_client_cert = $::certs::messaging_client_cert,
-) {
+
+  $country               = $::certs::country,
+  $state                 = $::certs::state,
+  $city                  = $::certs::city,
+  $org_unit              = $::certs::org_unit,
+  $expiration            = $::certs::expiration,
+  $default_ca            = $::certs::default_ca,
+  $ca_key_password_file  = $::certs::ca_key_password_file,
+) inherits certs {
 
   $qpid_client_cert_name = "${hostname}-qpid-client-cert"
 
@@ -17,17 +24,17 @@ class certs::qpid_client (
     cname         => $cname,
     common_name   => 'pulp-qpid-client-cert',
     purpose       => client,
-    country       => $::certs::country,
-    state         => $::certs::state,
-    city          => $::certs::city,
+    country       => $country,
+    state         => $state,
+    city          => $city,
     org           => 'PULP',
-    org_unit      => $::certs::org_unit,
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    org_unit      => $org_unit,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   if $deploy {

--- a/manifests/qpid_router.pp
+++ b/manifests/qpid_router.pp
@@ -1,5 +1,5 @@
 # Constains certs specific configurations for qpid dispatch router
-class certs::qpid_router(
+class certs::qpid_router (
   $hostname               = $::certs::node_fqdn,
   $cname                  = $::certs::cname,
   $generate               = $::certs::generate,
@@ -11,7 +11,15 @@ class certs::qpid_router(
   $client_key             = $::certs::qpid_router_client_key,
   $owner                  = $::certs::qpid_router_owner,
   $group                  = $::certs::qpid_router_group,
-) inherits certs::params {
+
+  $country               = $::certs::country,
+  $state                 = $::certs::state,
+  $city                  = $::certs::city,
+  $org_unit              = $::certs::org_unit,
+  $expiration            = $::certs::expiration,
+  $default_ca            = $::certs::default_ca,
+  $ca_key_password_file  = $::certs::ca_key_password_file,
+) inherits certs {
 
   $server_keypair = "${hostname}-qpid-router-server"
   $client_keypair = "${hostname}-qpid-router-client"
@@ -20,36 +28,36 @@ class certs::qpid_router(
     ensure        => present,
     hostname      => $hostname,
     cname         => $cname,
-    country       => $::certs::country,
-    state         => $::certs::state,
-    city          => $::certs::city,
+    country       => $country,
+    state         => $state,
+    city          => $city,
     org           => 'dispatch server',
-    org_unit      => $::certs::org_unit,
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    org_unit      => $org_unit,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
     purpose       => 'server',
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   cert { $client_keypair:
     ensure        => present,
     hostname      => $hostname,
     cname         => $cname,
-    country       => $::certs::country,
-    state         => $::certs::state,
-    city          => $::certs::city,
+    country       => $country,
+    state         => $state,
+    city          => $city,
     org           => 'dispatch client',
-    org_unit      => $::certs::org_unit,
-    expiration    => $::certs::expiration,
-    ca            => $::certs::default_ca,
+    org_unit      => $org_unit,
+    expiration    => $expiration,
+    ca            => $default_ca,
     generate      => $generate,
     regenerate    => $regenerate,
     deploy        => $deploy,
     purpose       => 'client',
-    password_file => $::certs::ca_key_password_file,
+    password_file => $ca_key_password_file,
   }
 
   if $deploy {

--- a/spec/classes/certs_apache_spec.rb
+++ b/spec/classes/certs_apache_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'certs::apache' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  describe 'with default parameters' do
+    it { should compile.with_all_deps }
+  end
+end

--- a/spec/classes/certs_candlepin_spec.rb
+++ b/spec/classes/certs_candlepin_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'certs::candlepin' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  let :pre_condition do
+    "service{'qpidd': }"
+  end
+
+  describe 'with default parameters' do
+    it { should compile.with_all_deps }
+  end
+end

--- a/spec/classes/certs_foreman_proxy_content_spec.rb
+++ b/spec/classes/certs_foreman_proxy_content_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'certs::foreman_proxy_content' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  let :pre_condition do
+    "
+package{ 'qpid-cpp-server': }
+class { 'puppet':
+  server_foreman => false,
+  agent => false,
+  server => true,
+}
+    "
+  end
+
+  let :params do
+    {
+      :certs_tar => '/tmp/tar'
+    }
+  end
+
+  describe 'with default parameters' do
+    it { should compile.with_all_deps }
+  end
+end

--- a/spec/classes/certs_foreman_proxy_spec.rb
+++ b/spec/classes/certs_foreman_proxy_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'certs::foreman_proxy' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  describe 'with default parameters' do
+    it { should compile.with_all_deps }
+  end
+end

--- a/spec/classes/certs_pulp_client_spec.rb
+++ b/spec/classes/certs_pulp_client_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'certs::pulp_client' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  describe 'with default parameters' do
+    it { should compile.with_all_deps }
+  end
+end

--- a/spec/classes/certs_puppet_spec.rb
+++ b/spec/classes/certs_puppet_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'certs::puppet' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  let :pre_condition do
+    "
+class { 'puppet':
+  server_foreman => false,
+  agent => false,
+  server => true,
+}
+    "
+  end
+
+  describe 'with default parameters' do
+    it { should compile.with_all_deps }
+  end
+end

--- a/spec/classes/certs_qpid_router_spec.rb
+++ b/spec/classes/certs_qpid_router_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'certs::qpid_router' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  describe 'with default parameters' do
+    it { should compile.with_all_deps }
+  end
+end

--- a/spec/classes/certs_qpid_spec.rb
+++ b/spec/classes/certs_qpid_spec.rb
@@ -8,10 +8,6 @@ describe 'certs::qpid' do
       end
 
       describe "without parameters" do
-        let :pre_condition do
-          'include ::certs'
-        end
-
         it { is_expected.to compile.with_all_deps }
 
         it do


### PR DESCRIPTION
As promised, this is the first PR to clean up the certs module. It includes some very basic test coverage. I want to extend it when working on the following list:

More issues we should fix:

* Client certs should not have a cname
* This module should not have any dependencies to tomcat, apache or whatever. The resource ordering should be done in the katello module.
* The classes that actually generate certificates should be defined types to allow reuse.