### PR TITLE
foreman_proxy does not need foreman user

### DIFF
--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -107,7 +107,6 @@ class certs::foreman_proxy (
     } ~>
     file { $foreman_proxy_ssl_client_bundle:
       ensure => file,
-      owner  => $::certs::group,
       mode   => '0644',
     } ~>
     file { $foreman_ssl_key:


### PR DESCRIPTION
The file is world readable, setting the owner to user
`foreman` causes errors because a user named `foreman` does not exist
on a system with just foreman proxy installed.
Removing the owner causes the file to be owned by root which is fine as
it is world readable.