### PR TITLE
extract nssdb creation into separate class

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -48,6 +48,7 @@ class certs::candlepin (
   $client_key = "${::certs::pki_dir}/private/${java_client_cert_name}.key"
 
   if $deploy {
+    include ::certs::ssltools::nssdb
 
     file { $password_file:
       ensure  => file,

--- a/manifests/ssltools/certutil.pp
+++ b/manifests/ssltools/certutil.pp
@@ -1,6 +1,8 @@
 # type to append cert to nssdb
 define certs::ssltools::certutil($nss_db_dir, $client_cert, $cert_name=$title, $refreshonly = true, $trustargs = ',,') {
-  Exec['create-nss-db'] ->
+  include ::certs::ssltools::nssdb
+
+  Class['::certs::ssltools::nssdb'] ->
   exec { "delete ${cert_name}":
     path        => ['/bin', '/usr/bin'],
     command     => "certutil -D -d ${nss_db_dir} -n '${cert_name}'",

--- a/manifests/ssltools/nssdb.pp
+++ b/manifests/ssltools/nssdb.pp
@@ -1,0 +1,42 @@
+# Sets up nssdb
+class certs::ssltools::nssdb (
+  $nss_db_dir = $::certs::nss_db_dir,
+  $group = $::certs::qpidd_group,
+)  {
+  Exec { logoutput => 'on_failure' }
+
+  $nss_db_password_file   = "${nss_db_dir}/nss_db_password-file"
+  $nssdb_files            = ["${nss_db_dir}/cert8.db", "${nss_db_dir}/key3.db", "${nss_db_dir}/secmod.db"]
+
+  file { $nss_db_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => $group,
+    mode   => '0755',
+  } ->
+  exec { 'generate-nss-password':
+    command => "openssl rand -base64 24 > ${nss_db_password_file}",
+    path    => '/usr/bin',
+    umask   => '0027',
+    group   => $group,
+    creates => $nss_db_password_file,
+  } ->
+  file { $nss_db_password_file:
+    ensure => file,
+    owner  => 'root',
+    group  => $group,
+    mode   => '0640',
+  } ->
+  exec { 'create-nss-db':
+    command => "certutil -N -d '${nss_db_dir}' -f '${nss_db_password_file}'",
+    path    => '/usr/bin',
+    umask   => '0027',
+    group   => $group,
+    creates => $nssdb_files,
+  } ->
+  file { $nssdb_files:
+    owner => 'root',
+    group => $group,
+    mode  => '0640',
+  }
+}


### PR DESCRIPTION
Both `qpidd` and `candlepin` need the `nssdb` present. This commit extracts the code to a common class.