### PR TITLE
move qpidd reload to katello module

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -80,7 +80,6 @@ class certs::candlepin (
       client_cert => $client_cert,
       refreshonly => true,
       subscribe   => Exec['create-nss-db'],
-      notify      => Service['qpidd'],
     } ~>
     file { $amqp_store_dir:
       ensure => directory,


### PR DESCRIPTION
This should go into the katello module. I haven't written the code for the module, yet. Currently, this is just a reminder.