### PR TITLE
remove dependencies to external modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@ fixtures:
   repositories:
     stdlib:            "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     extlib:            "https://github.com/puppet-community/puppet-extlib"
-    foreman:           "https://github.com/theforeman/puppet-foreman.git"
     common:            "https://github.com/katello/puppet-common.git"
     trusted_ca:        "https://github.com/jlambert121/jlambert121-trusted_ca"
     concat:            "https://github.com/puppetlabs/puppetlabs-concat"

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -65,7 +65,6 @@ class certs::candlepin (
       target => $keystore,
       owner  => 'tomcat',
       group  => $::certs::group,
-      notify => Service[$tomcat],
     }
 
     Cert[$java_client_cert_name] ~>
@@ -108,7 +107,6 @@ class certs::candlepin (
       owner  => 'tomcat',
       group  => $::certs::group,
       mode   => '0640',
-      notify => Service[$tomcat],
     }
   }
 }

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -72,23 +72,19 @@ class certs::foreman_proxy (
     Cert[$proxy_cert_name] ~>
     pubkey { $proxy_cert:
       key_pair => Cert[$proxy_cert_name],
-      notify   => Service['foreman-proxy'],
     } ~>
     privkey { $proxy_key:
       key_pair => Cert[$proxy_cert_name],
-      notify   => Service['foreman-proxy'],
     } ->
     pubkey { $proxy_ca_cert:
       key_pair => $::certs::default_ca,
-      notify   => Service['foreman-proxy'],
     } ~>
     file { $proxy_key:
       ensure => file,
       owner  => 'foreman-proxy',
       group  => $::certs::group,
       mode   => '0400',
-    } ~>
-    Service['foreman-proxy']
+    }
 
     Cert[$foreman_proxy_client_cert_name] ~>
     pubkey { $foreman_ssl_cert:

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -97,8 +97,7 @@ class certs::qpid (
       command     => "pk12util -i '${pfx_path}' -d '${::certs::nss_db_dir}' -w '${nss_db_password_file}' -k '${nss_db_password_file}'",
       path        => '/usr/bin',
       refreshonly => true,
-    } ~>
-    Service['qpidd']
+    }
 
     Pubkey[$::certs::ca_cert] ~> Certs::Ssltools::Certutil['ca']
     Pubkey[$client_cert] ~> Certs::Ssltools::Certutil['broker']


### PR DESCRIPTION
This commit removes dependencies to external services.

They should be defined in a profile module, something like this:

```puppet
# puppet-katello
Certs::Ssltools::Certutil <| |> ~> Service['qpidd']
Class['certs::apache'] -> Service['httpd']
Class['certs::candlepin'] ~> Service['tomcat']
Class['certs::qpid'] ~> Service['qpidd']

# puppet-foreman_proxy_content
Class['certs::foreman_proxy'] ~> Service['foreman_proxy']

# on a katello:puppet class (which does not exist, yet)
Class['puppet::server::install'] -> Class['certs::puppet']
```