### PR TITLE
Fix qpid dependency on apache

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -42,7 +42,7 @@ class certs::qpid (
       key_file   => $client_key,
       manage_key => true,
       key_owner  => 'root',
-      key_group  => 'apache',
+      key_group  => $::certs::qpidd_group,
       key_mode   => '0440',
       cert_file  => $client_cert,
     } ~>


### PR DESCRIPTION
In bf4d1d9b63baa1cbaa573ae9e26e53d78ead46c2 the dependency on Apache was
removed but accidentally reintroduced in
0758e06b1d977741b5e6bc4167629eb9eafd36d3.