### PR TITLE
Add an acceptance test for candlepin

### DIFF
--- a/manifests/ssltools/nssdb.pp
+++ b/manifests/ssltools/nssdb.pp
@@ -8,6 +8,8 @@ class certs::ssltools::nssdb (
   $nss_db_password_file   = "${nss_db_dir}/nss_db_password-file"
   $nssdb_files            = ["${nss_db_dir}/cert8.db", "${nss_db_dir}/key3.db", "${nss_db_dir}/secmod.db"]
 
+  ensure_packages(['openssl', 'nss-tools'])
+
   file { $nss_db_dir:
     ensure => directory,
     owner  => 'root',
@@ -20,6 +22,7 @@ class certs::ssltools::nssdb (
     umask   => '0027',
     group   => $group,
     creates => $nss_db_password_file,
+    require => Package['openssl'],
   } ->
   file { $nss_db_password_file:
     ensure => file,
@@ -33,6 +36,7 @@ class certs::ssltools::nssdb (
     umask   => '0027',
     group   => $group,
     creates => $nssdb_files,
+    require => Package['nss-tools'],
   } ->
   file { $nssdb_files:
     owner => 'root',

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper_acceptance'
+
+describe 'certs' do
+  before(:all) do
+    install_repo = <<-EOS
+      yumrepo { 'katello':
+        descr    => 'Katello latest',
+        baseurl  => 'https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/$basearch/',
+        gpgcheck => false,
+        enabled  => true,
+      }
+    EOS
+
+    apply_manifest(install_repo)
+  end
+
+  context 'with default params' do
+    let(:pp) do
+      <<-EOS
+      user { 'tomcat':
+        ensure => present,
+      }
+
+      group { 'qpidd':
+        ensure => present,
+      }
+
+      ['/usr/share/tomcat/conf', '/etc/candlepin/certs/amqp'].each |$dir| {
+        exec { "mkdir -p ${dir}":
+          creates => $dir,
+          path    => ['/bin', '/usr/bin'],
+        }
+      }
+
+      package { 'java-1.8.0-openjdk-headless':
+        ensure => installed,
+      }
+
+      include ::certs::candlepin
+      EOS
+    end
+
+    keystore_password_file = '/etc/pki/katello/keystore_password-file'
+
+    it_behaves_like 'a idempotent resource'
+
+    describe x509_certificate('/etc/pki/katello/certs/katello-tomcat.crt') do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'server' }
+      its(:issuer) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:subject) { should eq "/C=US/ST=North Carolina/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_private_key('/etc/pki/katello/private/katello-tomcat.key') do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate('/etc/pki/katello/certs/katello-tomcat.crt') }
+    end
+
+    describe x509_certificate('/etc/pki/katello/certs/java-client.crt') do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'server' }
+      its(:issuer) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:subject) { should eq "/C=US/ST=North Carolina/O=candlepin/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_private_key('/etc/pki/katello/private/java-client.key') do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate('/etc/pki/katello/certs/java-client.crt') }
+    end
+
+    describe file(keystore_password_file) do
+      it { should be_file }
+      it { should be_mode 440 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+    end
+
+    describe file('/etc/pki/katello/keystore') do
+      it { should be_file }
+      it { should be_mode 644 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+    end
+
+    describe command("keytool -list -keystore /etc/pki/katello/keystore -storepass $(cat #{keystore_password_file})") do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/^Keystore type: JKS$/) }
+      its(:stdout) { should match(/^Your keystore contains 1 entry$/) }
+      its(:stdout) { should match(/^tomcat, .+, PrivateKeyEntry, $/) }
+    end
+
+    describe command("keytool -list -keystore /etc/candlepin/certs/amqp/candlepin.truststore -storepass $(cat #{keystore_password_file})") do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/^Keystore type: JKS$/) }
+      its(:stdout) { should match(/^Your keystore contains 1 entry$/) }
+      its(:stdout) { should match(/^katello-default-ca, .+, trustedCertEntry, $/) }
+    end
+
+    describe command("keytool -list -keystore /etc/candlepin/certs/amqp/candlepin.jks -storepass $(cat #{keystore_password_file})") do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/^Keystore type: JKS$/) }
+      its(:stdout) { should match(/^Your keystore contains 1 entry$/) }
+      its(:stdout) { should match(/^amqp-client, .+, PrivateKeyEntry, $/) }
+    end
+  end
+end


### PR DESCRIPTION
This is how an acceptance test for candlepin could look like. Currently it doesn't pass yet and we should move more code into common areas to manage the repositories.

This includes https://github.com/Katello/puppet-certs/pull/144, builds on https://github.com/Katello/foreman-installer-modulesync/pull/20 and relates to https://github.com/Katello/puppet-pulp/issues/164.