### PR TITLE
Remove a dependency on theforeman-foreman

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,10 +25,6 @@
       "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
-      "name": "theforeman-foreman",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
-    },
-    {
       "name": "katello-common",
       "version_requirement": ">= 1.0.0 < 2.0.0"
     }


### PR DESCRIPTION
This was added for the random_password function but that has been moved
to puppet-extlib.

Or am I missing something?