### PR TITLE
fixes #19259 - apache key should be mode 0440

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -52,7 +52,7 @@ class certs::apache (
       key_file   => $apache_key,
       manage_key => true,
       key_owner  => $::apache::user,
-      key_mode   => '0400',
+      key_mode   => '0440',
       key_group  => $::certs::group,
       cert_file  => $apache_cert,
       notify     => Service['httpd'],


### PR DESCRIPTION
Foreman launches websockify process that needs read access to
this key.