### PR TITLE
fixes #19271 - do not restart docker service

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -79,15 +79,6 @@ if [ -d $CA_TRUST_ANCHORS ]; then
   update-ca-trust enable
   cp $KATELLO_CERT_DIR/$KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
   update-ca-trust
-
-  # restart docker if it is installed and running
-  if [ -f /usr/lib/systemd/system/docker.service ]; then
-    systemctl status docker >/dev/null && \
-    systemctl restart docker >/dev/null 2&>1
-  elif [ -f /etc/init.d/docker ]; then
-    service docker status >/dev/null && \
-    service docker restart >/dev/null 2&>1
-  fi
 fi
 
 # restart goferd if it is installed and running


### PR DESCRIPTION
Restarting things that aren't ours is *very* bad behavior.

This means that any Katello client at all will have docker restarted - when it possibly runs containers, taking them down.  The only reason for the restart is so docker sees the updated CA trust.  Not everyone wants to manage docker with Katello either, they could just want us for software updates, and here we are taking down all of their containers on them :-(

