### PR TITLE
Fixes #19271 - reload docker instead of restart

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -80,13 +80,13 @@ if [ -d $CA_TRUST_ANCHORS ]; then
   cp $KATELLO_CERT_DIR/$KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
   update-ca-trust
 
-  # restart docker if it is installed and running
+  # reload docker if it is installed and running
   if [ -f /usr/lib/systemd/system/docker.service ]; then
     systemctl status docker >/dev/null && \
-    systemctl restart docker >/dev/null 2&>1
+    systemctl reload docker >/dev/null 2&>1
   elif [ -f /etc/init.d/docker ]; then
     service docker status >/dev/null && \
-    service docker restart >/dev/null 2&>1
+    service docker reload >/dev/null 2&>1
   fi
 fi
 


### PR DESCRIPTION
Restarting docker service will stop all the running containers, so instead of restart we should reload the service which will not affect any running container.