### PR TITLE
Fixes #19734 - enforce proper exection order for Candlepin

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -105,8 +105,7 @@ class certs::candlepin (
       target => $keystore,
       owner  => 'tomcat',
       group  => $group,
-    }
-
+    } ->
     certs::keypair { 'candlepin':
       key_pair  => $java_client_cert_name,
       key_file  => $client_key,


### PR DESCRIPTION
otherwise `Exec[import client certificate into Candlepin keystore]` has no relationship with `File[/etc/pki/katello/keystore_password-file]` and Puppet might execute them in any order, but the Exec needs the File.