### PR TITLE
#19578 - Switch to custom datatype for path validation

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -13,7 +13,7 @@
 #                                   type:Array
 #
 # $certs_tar::                      Path to tar file with certs to generate
-#                                   type:Optional[Certs::Relativeunixpath]
+#                                   type:Optional[String]
 #
 class certs::foreman_proxy_content (
   $parent_fqdn          = $::fqdn,

--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -13,7 +13,7 @@
 #                                   type:Array
 #
 # $certs_tar::                      Path to tar file with certs to generate
-#                                   type:Optional[Stdlib::Absolutepath]
+#                                   type:Optional[Certs::Relativeunixpath]
 #
 class certs::foreman_proxy_content (
   $parent_fqdn          = $::fqdn,

--- a/types/relativeunixpath.pp
+++ b/types/relativeunixpath.pp
@@ -1,0 +1,2 @@
+# this regex rejects any path component that is a / or a NUL
+type Certs::Relativeunixpath = Pattern[/^(\.{2}|~)?\/([^\/\0]+?\/*?)+?$/]

--- a/types/relativeunixpath.pp
+++ b/types/relativeunixpath.pp
@@ -1,2 +1,0 @@
-# this regex rejects any path component that is a / or a NUL
-type Certs::Relativeunixpath = Pattern[/^(\.{2}|~)?\/([^\/\0]+?\/*?)+?$/]


### PR DESCRIPTION
No puppetlabs-stdlib data type exists for any sort of relative url, so we have to roll our own. This could _probably_ go into a more generic module, but I figured for simplicity of not having 3+ chained PRs...

http://projects.theforeman.org/issues/19578