### PR TITLE
Add acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,7 @@
 ---
+.travis.yml:
+  beaker_sets:
+  - docker/centos-7
 Rakefile:
   param_docs_pattern:
     - manifests/foreman_proxy_content.pp

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,11 @@ matrix:
       env: PUPPET_VERSION=4.6 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
     - rvm: 2.4.1
       env: PUPPET_VERSION=5.0 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
 bundler_args: --without system_tests development
 sudo: false

--- a/spec/acceptance/certs_spec.rb
+++ b/spec/acceptance/certs_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper_acceptance'
+
+describe 'certs' do
+  before(:all) do
+    install_repo = <<-EOS
+      yumrepo { 'katello':
+        descr    => 'Katello latest',
+        baseurl  => 'https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/$basearch/',
+        gpgcheck => false,
+        enabled  => true,
+      }
+    EOS
+
+    apply_manifest(install_repo)
+  end
+
+  context 'with default params' do
+    let(:pp) do
+      'include ::certs'
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    describe package('katello-certs-tools') do
+      it { is_expected.to be_installed }
+    end
+
+    describe x509_certificate('/etc/pki/katello-certs-tools/certs/katello-default-ca.crt') do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'SSL server CA' }
+      its(:issuer) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:subject) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_certificate('/etc/pki/katello-certs-tools/certs/katello-server-ca.crt') do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'SSL server CA' }
+      its(:issuer) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:subject) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_certificate('/etc/pki/katello/certs/katello-default-ca.crt') do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'SSL server CA' }
+      its(:issuer) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:subject) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_certificate('/etc/pki/katello/certs/katello-server-ca.crt') do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'SSL server CA' }
+      its(:issuer) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:subject) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_private_key('/etc/pki/katello/private/katello-default-ca.key') do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate('/etc/pki/katello-certs-tools/certs/katello-default-ca.crt') }
+    end
+  end
+end


### PR DESCRIPTION
Based on https://github.com/Katello/puppet-certs/pull/160 with some slight changes. I'll expand this later to more classes so we have a baseline of working manifests before I attempt to refactor.