### PR TITLE
Drop apache username/password

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -17,7 +17,6 @@ class certs::apache (
   $expiration           = $::certs::expiration,
   $default_ca           = $::certs::default_ca,
   $ca_key_password_file = $::certs::ca_key_password_file,
-  $group                = $::certs::group,
 ) inherits certs {
 
   $apache_cert_name = "${hostname}-apache"
@@ -56,18 +55,14 @@ class certs::apache (
   }
 
   if $deploy {
-
-    include ::apache
-
     certs::keypair { 'apache':
       key_pair   => $apache_cert_name,
       key_file   => $apache_key,
       manage_key => true,
-      key_owner  => $::apache::user,
+      key_owner  => 'root',
+      key_group  => 'root',
       key_mode   => '0440',
-      key_group  => $group,
       cert_file  => $apache_cert,
-      notify     => Service['httpd'],
     }
   }
 }

--- a/spec/acceptance/apache_spec.rb
+++ b/spec/acceptance/apache_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper_acceptance'
+
+describe 'certs::apache' do
+  before(:all) do
+    install_repo = <<-EOS
+      yumrepo { 'katello':
+        descr    => 'Katello latest',
+        baseurl  => 'https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/$basearch/',
+        gpgcheck => false,
+        enabled  => true,
+      }
+    EOS
+
+    apply_manifest(install_repo)
+  end
+
+  context 'with default parameters' do
+    let(:pp) do
+      'include ::certs::apache'
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    describe x509_certificate('/etc/pki/katello/certs/katello-apache.crt') do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'server' }
+      its(:issuer) { should eq "/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:subject) { should eq "/C=US/ST=North Carolina/O=Katello/OU=SomeOrgUnit/CN=#{fact('fqdn')}" }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_private_key('/etc/pki/katello/private/katello-apache.key') do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate('/etc/pki/katello/certs/katello-apache.crt') }
+    end
+  end
+end


### PR DESCRIPTION
This reduces coupling to other modules and will allow much easier testing while increasing security.

Apache uses the root user to read certificates and private keys so we can tighten the permissions to ```root:root 0640```.

In puppet-katello we already subscribe to it [here](https://github.com/Katello/puppet-katello/blob/451530b0b161d41ab09f10333f3e849c82cda70d/manifests/application.pp#L52) and that is equal.

In puppet-foreman_proxy_content we subscribe to it [here](https://github.com/Katello/puppet-foreman_proxy_content/blob/c0a476813ecda9cdc0af324faa3c8be05c886364/manifests/init.pp#L116-L125) but I'm not 100% sure yet if this is equal. Ordering should be correct but if Apache is actually reloaded is not guaranteed. https://github.com/Katello/puppet-foreman_proxy_content/pull/136 will fix this.