### PR TITLE
Stop managing tomcat keystore symlink

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -13,7 +13,6 @@ class certs::candlepin (
   $amqp_truststore        = $::certs::candlepin_amqp_truststore,
   $amqp_keystore          = $::certs::candlepin_amqp_keystore,
   $amqp_store_dir         = $::certs::candlepin_amqp_store_dir,
-  $tomcat                 = $::certs::tomcat,
   $country                = $::certs::country,
   $state                  = $::certs::state,
   $city                   = $::certs::city,
@@ -97,12 +96,6 @@ class certs::candlepin (
       command => "openssl pkcs12 -export -in ${tomcat_cert} -inkey ${tomcat_key} -out ${keystore} -name tomcat -CAfile ${ca_cert} -caname root -password \"file:${password_file}\" -passin \"file:${ca_key_password_file}\" ",
       creates => $keystore,
     } ~>
-    file { "/usr/share/${tomcat}/conf/keystore":
-      ensure => link,
-      target => $keystore,
-      owner  => 'tomcat',
-      group  => $group,
-    } ->
     certs::keypair { 'candlepin':
       key_pair  => $java_client_cert_name,
       key_file  => $client_key,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,6 @@
 # Certs Parameters
 class certs::params {
 
-  $tomcat = 'tomcat'
-
   $log_dir = '/var/log/certs'
   $pki_dir = '/etc/pki/katello'
   $ssl_build_dir = '/root/ssl-build'

--- a/spec/classes/certs_candlepin_spec.rb
+++ b/spec/classes/certs_candlepin_spec.rb
@@ -5,10 +5,6 @@ describe 'certs::candlepin' do
     on_supported_os['redhat-7-x86_64']
   end
 
-  let :pre_condition do
-    "service{'qpidd': }"
-  end
-
   describe 'with default parameters' do
     it { should compile.with_all_deps }
   end


### PR DESCRIPTION
https://github.com/Katello/puppet-katello/commit/4e1371e8c93d75465b1f5b5f8fd025b90c8b9424 started to manage think symlink as well. That means we can stop managing it here.