### PR TITLE
Use implicit dependency chaining on puppet

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,5 @@ fixtures:
     common:            "https://github.com/katello/puppet-common.git"
     trusted_ca:        "https://github.com/jlambert121/jlambert121-trusted_ca"
     concat:            "https://github.com/puppetlabs/puppetlabs-concat"
-    apache:            "https://github.com/puppetlabs/puppetlabs-apache"
-    puppet:            "https://github.com/theforeman/puppet-puppet"
   symlinks:
     certs: "#{source_dir}"

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -43,10 +43,9 @@ class certs::puppet (
 
   if $deploy {
     file { "${pki_dir}/puppet":
-      ensure  => directory,
-      owner   => 'puppet',
-      mode    => '0700',
-      require => Class['puppet::server::install'],
+      ensure => directory,
+      owner  => 'puppet',
+      mode   => '0700',
     } ->
     certs::keypair { 'puppet':
       key_pair    => $puppet_client_cert_name,

--- a/spec/classes/certs_foreman_proxy_content_spec.rb
+++ b/spec/classes/certs_foreman_proxy_content_spec.rb
@@ -5,17 +5,6 @@ describe 'certs::foreman_proxy_content' do
     on_supported_os['redhat-7-x86_64']
   end
 
-  let :pre_condition do
-    "
-package{ 'qpid-cpp-server': }
-class { 'puppet':
-  server_foreman => false,
-  agent => false,
-  server => true,
-}
-    "
-  end
-
   let :params do
     {
       :certs_tar => '/tmp/tar'

--- a/spec/classes/certs_puppet_spec.rb
+++ b/spec/classes/certs_puppet_spec.rb
@@ -5,16 +5,6 @@ describe 'certs::puppet' do
     on_supported_os['redhat-7-x86_64']
   end
 
-  let :pre_condition do
-    "
-class { 'puppet':
-  server_foreman => false,
-  agent => false,
-  server => true,
-}
-    "
-  end
-
   describe 'with default parameters' do
     it { should compile.with_all_deps }
   end


### PR DESCRIPTION
https://github.com/theforeman/puppet-puppet/commit/2fb8ad506566092d146492f49e7892ca0fb93b64 ensures the puppet user is always managed. This means the file resource will autorequire the user causing the chaining to work.