### PR TITLE
Correct stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.2.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 5.0.0"
     },
     {
       "name": "puppet-extlib",


### PR DESCRIPTION
We use Stdlib::Absolutepath which was introduced in 4.13.0.