### PR TITLE
Bump version to 14.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-certs",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "author": "katello",
   "summary": "Deploys CA and required certs for a Foreman and Katello installation.",
   "license": "GPL-3.0+",


### PR DESCRIPTION
In preparation for the breaking change in https://github.com/theforeman/puppet-certs/pull/370. This requires first merging:

 - [x] https://github.com/theforeman/puppet-katello/pull/431
 - [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/389