### PR TITLE
Add certs for IoP

### DIFF
--- a/manifests/iop.pp
+++ b/manifests/iop.pp
@@ -1,0 +1,62 @@
+# Contains certs specific configurations for IOP
+class certs::iop (
+  Stdlib::Fqdn $hostname = 'localhost',
+  Boolean $generate = $certs::generate,
+  Boolean $regenerate = $certs::regenerate,
+  Boolean $deploy = $certs::deploy,
+  String[2,2] $country = $certs::country,
+  String $state = $certs::state,
+  String $city = $certs::city,
+  String $org = $certs::org,
+  String $org_unit = $certs::org_unit,
+  String $expiration = $certs::expiration,
+  Stdlib::Absolutepath $ca_key_password_file = $certs::ca_key_password_file,
+  String $owner = 'root',
+  String $group = 'root',
+  Stdlib::Filemode $private_key_mode = '0440',
+  Stdlib::Filemode $public_key_mode = '0444',
+) inherits certs {
+  $server_cert_name = "${hostname}-iop-core-gateway-server"
+  $client_cert_name = "${hostname}-iop-core-gateway-client"
+
+  cert { $server_cert_name:
+    ensure        => present,
+    hostname      => $hostname,
+    country       => $country,
+    state         => $state,
+    city          => $city,
+    org           => $org,
+    org_unit      => $org_unit,
+    expiration    => $expiration,
+    ca            => $certs::default_ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
+  }
+
+  cert { $client_cert_name:
+    ensure        => present,
+    purpose       => 'client',
+    hostname      => $hostname,
+    country       => $country,
+    state         => $state,
+    city          => $city,
+    org           => $org,
+    org_unit      => $org_unit,
+    expiration    => $expiration,
+    ca            => $certs::default_ca,
+    generate      => $generate,
+    regenerate    => $regenerate,
+    password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
+  }
+
+  $server_cert = "${certs::ssl_build_dir}/${hostname}/${server_cert_name}.crt"
+  $server_key = "${certs::ssl_build_dir}/${hostname}/${server_cert_name}.key"
+  $server_ca_cert = $certs::katello_default_ca_cert
+
+  $client_cert = "${certs::ssl_build_dir}/${hostname}/${client_cert_name}.crt"
+  $client_key = "${certs::ssl_build_dir}/${hostname}/${client_cert_name}.key"
+  $client_ca_cert = $certs::katello_server_ca_cert
+}

--- a/spec/acceptance/iop_spec.rb
+++ b/spec/acceptance/iop_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper_acceptance'
+
+describe 'certs::iop' do
+  fqdn = fact('fqdn')
+  hostname = 'localhost'
+
+  before(:all) do
+    on default, 'rm -rf /root/ssl-build'
+
+    manifest = <<~MANIFEST
+      file { '/etc/foreman-proxy':
+        ensure => directory,
+      }
+
+      group { 'foreman-proxy':
+        ensure => present,
+        system => true,
+      }
+    MANIFEST
+    apply_manifest(manifest, catch_failures: true)
+  end
+
+  context 'with default parameters' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) { 'include certs::iop' }
+    end
+
+    describe x509_certificate("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-server.crt") do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'SSL server' }
+      its(:issuer) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fqdn}/) }
+      its(:subject) { should match_without_whitespace(/C = US, ST = North Carolina, O = Katello, OU = SomeOrgUnit, CN = #{hostname}/) }
+      its(:keylength) { should be >= 4096 }
+    end
+
+    describe x509_private_key("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-server.key") do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-server.crt") }
+    end
+
+    describe x509_certificate("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-client.crt") do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'SSL client' }
+      its(:issuer) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fqdn}/) }
+      its(:subject) { should match_without_whitespace(/C = US, ST = North Carolina, O = Katello, OU = SomeOrgUnit, CN = #{hostname}/) }
+      its(:keylength) { should be >= 4096 }
+    end
+
+    describe x509_private_key("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-client.key") do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-client.crt") }
+    end
+
+    describe file('/etc/iop') do
+      it { should_not exist }
+    end
+  end
+
+  context 'with generate false' do
+    before(:context) do
+      on default, 'rm -rf /root/ssl-build'
+    end
+
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+          class { 'certs::iop':
+            generate => false
+          }
+        PUPPET
+      end
+    end
+
+    describe file("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-server.crt") do
+      it { should_not exist }
+    end
+
+    describe file("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-server.key") do
+      it { should_not exist }
+    end
+
+    describe file("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-client.crt") do
+      it { should_not exist }
+    end
+
+    describe file("/root/ssl-build/#{hostname}/#{hostname}-iop-core-gateway-client.key") do
+      it { should_not exist }
+    end
+
+    describe file('/etc/iop') do
+      it { should_not exist }
+    end
+  end
+end

--- a/spec/classes/certs_iop_spec.rb
+++ b/spec/classes/certs_iop_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe 'certs::iop' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let :facts do
+        os_facts
+      end
+
+      let(:pre_condition) { 'include certs' }
+
+      describe 'with default parameters' do
+        it { should compile.with_all_deps }
+
+        it 'should create server certificate' do
+          should contain_cert('localhost-iop-core-gateway-server').with(
+            :ensure        => 'present',
+            :hostname      => 'localhost',
+            :purpose       => nil,
+            :country       => 'US',
+            :state         => 'North Carolina',
+            :city          => 'Raleigh',
+            :org           => 'Katello',
+            :org_unit      => 'SomeOrgUnit',
+            :expiration    => '7300',
+            :generate      => true,
+            :regenerate    => false,
+            :password_file => '/root/ssl-build/katello-default-ca.pwd',
+            :build_dir     => '/root/ssl-build'
+          )
+        end
+
+        it 'should create client certificate' do
+          should contain_cert('localhost-iop-core-gateway-client').with(
+            :ensure        => 'present',
+            :hostname      => 'localhost',
+            :purpose       => 'client',
+            :country       => 'US',
+            :state         => 'North Carolina',
+            :city          => 'Raleigh',
+            :org           => 'Katello',
+            :org_unit      => 'SomeOrgUnit',
+            :expiration    => '7300',
+            :generate      => true,
+            :regenerate    => false,
+            :password_file => '/root/ssl-build/katello-default-ca.pwd',
+            :build_dir     => '/root/ssl-build'
+          )
+        end
+      end
+
+      describe 'with custom hostname' do
+        let(:params) { { :hostname => 'example.com' } }
+
+        it { should compile.with_all_deps }
+
+        it 'should create server certificate with custom hostname' do
+          should contain_cert('example.com-iop-core-gateway-server').with(
+            :hostname => 'example.com'
+          )
+        end
+
+        it 'should create client certificate with custom hostname' do
+          should contain_cert('example.com-iop-core-gateway-client').with(
+            :hostname => 'example.com'
+          )
+        end
+      end
+
+      describe 'with generate false' do
+        let(:params) { { :generate => false } }
+
+        it { should compile.with_all_deps }
+
+        it 'should create certificates with generate false' do
+          should contain_cert('localhost-iop-core-gateway-server').with(
+            :generate => false
+          )
+          should contain_cert('localhost-iop-core-gateway-client').with(
+            :generate => false
+          )
+        end
+      end
+
+      describe 'with regenerate true' do
+        let(:params) { { :regenerate => true } }
+
+        it { should compile.with_all_deps }
+
+        it 'should create certificates with regenerate true' do
+          should contain_cert('localhost-iop-core-gateway-server').with(
+            :regenerate => true
+          )
+          should contain_cert('localhost-iop-core-gateway-client').with(
+            :regenerate => true
+          )
+        end
+      end
+
+      describe 'with custom certificate attributes' do
+        let(:params) do
+          {
+            :country    => 'CA',
+            :state      => 'Ontario',
+            :city       => 'Toronto',
+            :org        => 'TestOrg',
+            :org_unit   => 'TestUnit',
+            :expiration => '3650'
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it 'should create certificates with custom attributes' do
+          should contain_cert('localhost-iop-core-gateway-server').with(
+            :country    => 'CA',
+            :state      => 'Ontario',
+            :city       => 'Toronto',
+            :org        => 'TestOrg',
+            :org_unit   => 'TestUnit',
+            :expiration => '3650'
+          )
+          should contain_cert('localhost-iop-core-gateway-client').with(
+            :country    => 'CA',
+            :state      => 'Ontario',
+            :city       => 'Toronto',
+            :org        => 'TestOrg',
+            :org_unit   => 'TestUnit',
+            :expiration => '3650'
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This add server and client certificates to be used by the IoP Gateway. This does not remove the iop_advisor_engine certificates yet as those should be cleaned up after switching implementation.